### PR TITLE
Add copy constructor.

### DIFF
--- a/SWI-cpp.h
+++ b/SWI-cpp.h
@@ -130,6 +130,7 @@ public:
   term_t ref;
 
   PlTerm();
+  PlTerm(const PlTerm &other) : ref(other.ref) {}
   PlTerm(term_t t)
   { ref = t;
   }


### PR DESCRIPTION
This prevents warnings from modern compilers and preserves the
existing copy semantics.

This addresses some of the comments in SWI-Prolog/swipl-devel#586, but does not address #3.