### PR TITLE
TEST: Added foreign language interface regression tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,17 @@ install_src(pkg_cpp_headers
 
 swipl_examples(test.cpp likes.cpp likes.pl test.pl README.md)
 
+# add_subdirectory(Tests) # DO NOT SUBMIT - remove this line
+
 pkg_doc(
     pl2cpp
     DEPENDS pkg_cpp_headers)
+
+test_libs(ffi)
+
+swipl_plugin(
+    test_ffi
+    MODULE range_ffi4pl
+    C_SOURCES range_ffi4pl.c
+    C_LIBS
+    PL_LIBS test_ffi.pl)

--- a/range_ffi4pl.c
+++ b/range_ffi4pl.c
@@ -1,0 +1,146 @@
+/*  Part of SWI-Prolog
+
+    Author:        Peter Ludemann
+    E-mail:        peter.ludemann@gmail.com
+    WWW:           http://www.swi-prolog.org
+    Copyright (c)  2017-2022, VU University Amsterdam
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in
+       the documentation and/or other materials provided with the
+       distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/* This is used by test_ffi.pl */
+
+/* This tests the C interface and not the C++ interface.
+   But it was most convenient to put the test here. */
+
+#include <SWI-Prolog.h>
+#include <SWI-Stream.h>
+#include <assert.h>
+#include <string.h>
+
+/* range_ffi/3 is used in regression tests
+   - PL_foreign_context() passing an int for the context.
+ */
+static foreign_t
+range_ffi(term_t t_low, term_t t_high, term_t t_result, control_t handle)
+{ long result;
+
+  switch( PL_foreign_control(handle) )
+  { case PL_FIRST_CALL:
+      if ( !PL_get_long_ex(t_low, &result) )
+	PL_fail;
+      break;
+    case PL_REDO:
+      result = PL_foreign_context(handle);
+      break;
+    case PL_PRUNED:
+      PL_succeed;
+    default:
+      assert(0);
+  }
+
+  { long high;
+    if ( !PL_get_long_ex(t_high, &high) ||
+	 result >= high ||
+	 !PL_unify_integer(t_result, result) )
+      PL_fail;
+    PL_retry(result + 1);
+  }
+}
+
+/* range_ffialloc/3 is used in regression tests
+   - PL_foreign_context_address() and malloc()-ed context.
+*/
+struct range_ctxt
+{ long i;
+};
+
+static foreign_t
+range_ffialloc(term_t t_low, term_t t_high, term_t t_result, control_t handle)
+{ struct range_ctxt *ctxt;
+
+  switch( PL_foreign_control(handle) )
+  { case PL_FIRST_CALL:
+      { long low;
+	if ( !PL_get_long_ex(t_low, &low) )
+	  PL_fail;
+	if ( !(ctxt = malloc(sizeof *ctxt) ) )
+	  return PL_resource_error("memory");
+	ctxt->i = low;
+      }
+      break;
+    case PL_REDO:
+      ctxt = PL_foreign_context_address(handle);
+      break;
+    case PL_PRUNED:
+      ctxt = PL_foreign_context_address(handle);
+      free(ctxt);
+      PL_succeed;
+    default:
+      assert(0);
+  }
+
+  { long high;
+    if ( !PL_get_long_ex(t_high, &high) ||
+	 ctxt->i >= high ||
+	 !PL_unify_integer(t_result, ctxt->i) )
+    { free(ctxt);
+      PL_fail;
+    }
+    ctxt->i += 1;
+    PL_retry_address(ctxt);
+  }
+}
+
+static char* range_ffi_str;
+#define RANGE_FFI_STR_LEN 100
+#define RANGE_FFI_STR_CONTENTS "RANGE_FFI"
+
+
+install_t
+install_range_ffi4pl(void)
+{ PL_register_foreign("range_ffi", 3, range_ffi, PL_FA_NONDETERMINISTIC);
+  PL_register_foreign("range_ffialloc", 3, range_ffialloc, PL_FA_NONDETERMINISTIC);
+  range_ffi_str = malloc(RANGE_FFI_STR_LEN);
+  assert(range_ffi_str);
+  strncpy(range_ffi_str, RANGE_FFI_STR_CONTENTS, RANGE_FFI_STR_LEN);
+  assert(0 == strncmp(range_ffi_str, RANGE_FFI_STR_CONTENTS, RANGE_FFI_STR_LEN));
+  #ifdef O_DEBUG
+    Sdprintf("install_range_ffi4pl %s\n", range_ffi_str);
+  #endif
+}
+
+install_t
+uninstall_range_ffi4pl(void)
+{ /* If run with ASAN, this also tests that cleanup is done */
+  #ifdef O_DEBUG
+    Sdprintf("uninstall_range_ffi4pl %s\n", range_ffi_str);
+  #endif
+  assert(0 == strncmp(range_ffi_str, RANGE_FFI_STR_CONTENTS, RANGE_FFI_STR_LEN));
+  free(range_ffi_str);
+}
+

--- a/test_ffi.pl
+++ b/test_ffi.pl
@@ -1,0 +1,87 @@
+/*  Part of SWI-Prolog
+
+    Author:        Peter Ludemann
+    E-mail:        peter.ludemann@gmail.com
+    WWW:           http://www.swi-prolog.org
+    Copyright (c)  2009, University of Amsterdam
+                         VU University Amsterdam
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in
+       the documentation and/or other materials provided with the
+       distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+
+% This tests the C interface and not the C++ interface.
+% But it was most convenient to put the test here.
+
+:- module(test_ffi,
+          [ test_ffi/0
+          ]).
+
+:- use_module(library(plunit)).
+
+:- use_foreign_library(foreign(range_ffi4pl)).
+
+test_ffi :-
+    run_tests([ ffi
+	      ]).
+
+:- begin_tests(ffi).
+
+test(range1, all(X == [1,2])) :-
+    range_ffi(1, 3, X).
+test(range2, all(X == [-2,-1,0,1,2])) :-
+    range_ffi(-2, 3, X).
+test(range3a, all(X == [-2])) :-
+    range_ffi(-2, -1, X).
+test(range3b, all(X == [0])) :-
+    range_ffi(0, 1, X).
+test(range3c, all(X == [10])) :-
+    range_ffi(10, 11, X).
+test(range4a, fail) :-
+    range_ffi(1, 1, _X).
+test(range4b, fail) :-
+    range_ffi(0, 0, _X).
+test(range4c, fail) :-
+    range_ffi(-1, -1, _X).
+
+test(range_ffialloc1, all(X == [1,2])) :-
+    range_ffialloc(1, 3, X).
+test(range_ffialloc2, all(X == [-2,-1,0,1,2])) :-
+    range_ffialloc(-2, 3, X).
+test(range_ffialloc3a, all(X == [0])) :-
+    range_ffialloc(0, 1, X).
+test(range_ffialloc3b, all(X == [10])) :-
+    range_ffialloc(10, 11, X).
+test(range_ffialloc3c, all(X == [-2])) :-
+    range_ffi(-2, -1, X).
+test(range_ffialloc4a, fail) :-
+    range_ffialloc(1, 1, _X).
+test(range_ffialloc4a, fail) :-
+    range_ffialloc(0, 0, _X).
+test(range_ffialloc4a, fail) :-
+    range_ffialloc(-1, -1, _X).
+
+:- end_tests(ffi).


### PR DESCRIPTION
As suggested by https://swi-prolog.discourse.group/t/pl-retry-and-non-positive-values/5198/11 , foreign language interface tests have been moved to here (packages-cpp) as the easiest way of doing things.