### PR TITLE
Suppress uninitialized warning

### DIFF
--- a/range_ffi4pl.c
+++ b/range_ffi4pl.c
@@ -104,6 +104,7 @@ range_ffialloc(term_t t_low, term_t t_high, term_t t_result, control_t handle)
       PL_succeed;
     default:
       assert(0);
+      PL_fail;
   }
 
   { long high;


### PR DESCRIPTION
warning: 'ctxt' may be used uninitialized in this function