### PR TITLE
Remove unnecessary move consructors + make a private constructor public

### DIFF
--- a/SWI-cpp2.cpp
+++ b/SWI-cpp2.cpp
@@ -303,9 +303,9 @@ PlTerm::as_pointer() const
 }
 
 _SWI_CPP2_CPP_inline
-PlRecordRaw
-PlTerm::record_raw() const
-{ PlRecordRaw rec(*this);
+PlRecord
+PlTerm::record() const
+{ PlRecord rec(*this);
   return rec;
 }
 

--- a/SWI-cpp2.h
+++ b/SWI-cpp2.h
@@ -161,8 +161,9 @@ public:
 
   WrappedC<C_t>(            const WrappedC<C_t>&) = default;
   WrappedC<C_t>& operator =(const WrappedC<C_t>&) = default;
-  WrappedC<C_t>(            WrappedC<C_t>&&) = default;
-  WrappedC<C_t>& operator =(WrappedC<C_t>&&) = default;
+  // This simple wrapper class doesn't need a move constructor or
+  // move operator=.
+
   ~WrappedC<C_t>() { }
 
   operator bool() const = delete; // Use not_null(), is_null() instead
@@ -369,10 +370,7 @@ public:
   { Plx_put_atom(C_, a.C_);
   }
 
-  // TODO: why do the copy/move constructors get rid of some warning messages
-  //       about deprecated operator = ?
   PlTerm(const PlTerm&) = default;
-  PlTerm(PlTerm&&) = default;
 
   // TODO: PlTerm& operator =(const PlTerm&) = delete; // TODO: when the deprecated items below are removed
 
@@ -750,9 +748,7 @@ public:
   }
 
   PlTermv(const PlTermv&) = default;
-  PlTermv(PlTermv&&) = default;
   PlTermv& operator =(const PlTermv&) = default;
-  PlTermv& operator =(PlTermv&&) = default;
   ~PlTermv() = default;
 
 
@@ -833,16 +829,16 @@ public:
     : WrappedC<record_t>(Plx_record(t.C_))
   { }
 
-  PlRecordRaw(const PlRecordRaw& r)
-    : WrappedC<record_t>(r) // TODO: r.duplicate();
+  explicit PlRecordRaw(record_t r)
+    : WrappedC<record_t>(r)
   { }
-  PlRecordRaw& operator =(const PlRecordRaw& r) = delete; // TODO: implement
-  PlRecordRaw& operator =(PlRecordRaw&&) = delete;        // TODO: implement
 
-  PlRecordRaw(PlRecordRaw&& r)
-    : WrappedC<record_t>(r) // TODO: r.duplicate; r.erase();
-  { if ( this != &r )
-      r.C_ = null;
+  PlRecordRaw(const PlRecordRaw& r)
+    : WrappedC<record_t>(r)
+  { }
+  PlRecordRaw& operator =(const PlRecordRaw& r)
+  { C_ = r.C_;
+    return *this;
   }
 
   PlTerm term() const
@@ -864,12 +860,6 @@ public:
   ~PlRecordRaw()
   { // TODO: erase();
   }
-
-private:
-  // Used by PlRecordRaw::duplicate:
-  explicit PlRecordRaw(record_t r)
-    : WrappedC<record_t>(r)
-  { }
 };
 
 
@@ -881,9 +871,7 @@ public:
   { }
 
   PlRecordExternalCopy(const PlRecordExternalCopy& r) = default;
-  PlRecordExternalCopy(PlRecordExternalCopy&& r) = default;
   PlRecordExternalCopy& operator =(const PlRecordExternalCopy&) = delete;
-  PlRecordExternalCopy& operator =(PlRecordExternalCopy&&) = default;
   ~PlRecordExternalCopy() = default;
 
   PlTerm term() const
@@ -1346,9 +1334,7 @@ public:
   }
 
   PlStream(const PlStream&) = default;
-  PlStream(PlStream&&) = default;
   PlStream& operator =(const PlStream&) = default;
-  PlStream& operator =(PlStream&&) = default;
 
   ~PlStream()
   { if (stream_ != nullptr)

--- a/SWI-cpp2.h
+++ b/SWI-cpp2.h
@@ -89,7 +89,7 @@ particularly integer conversions.
 class PlAtom;
 class PlTerm;
 class PlTermv;
-class PlRecordRaw;
+class PlRecord;
 class PlRecordExternalCopy;
 
 
@@ -470,7 +470,7 @@ public:
 
   // TODO: PL_unify_*()?
   // TODO: PL_skip_list()
-  PlRecordRaw record_raw() const;
+  PlRecord record() const;
 
 					/* PlTerm --> C */
   [[deprecated("use as_long()")]]     explicit operator long()     const { return as_long(); }
@@ -822,21 +822,21 @@ public:
 };
 
 
-class PlRecordRaw : public WrappedC<record_t>
+class PlRecord : public WrappedC<record_t>
 {
 public:
-  PlRecordRaw(PlTerm t)
+  PlRecord(PlTerm t)
     : WrappedC<record_t>(Plx_record(t.C_))
   { }
 
-  explicit PlRecordRaw(record_t r)
+  explicit PlRecord(record_t r)
     : WrappedC<record_t>(r)
   { }
 
-  PlRecordRaw(const PlRecordRaw& r)
+  PlRecord(const PlRecord& r)
     : WrappedC<record_t>(r)
   { }
-  PlRecordRaw& operator =(const PlRecordRaw& r)
+  PlRecord& operator =(const PlRecord& r)
   { C_ = r.C_;
     return *this;
   }
@@ -853,12 +853,22 @@ public:
     C_ = null;
   }
 
-  PlRecordRaw duplicate() const
-  { return PlRecordRaw(Plx_duplicate_record(C_));
+  PlRecord duplicate() const
+  { return PlRecord(Plx_duplicate_record(C_));
   }
 
-  ~PlRecordRaw()
+  ~PlRecord()
   { // TODO: erase();
+  }
+};
+
+
+class PlRecordDeleter
+{
+public:
+  void operator()(PlRecord *r) const
+  { r->erase();
+    delete r;
   }
 };
 
@@ -995,7 +1005,7 @@ protected:
     term_rec_.set_null();
   }
 
-  PlRecordRaw term_rec_;
+  PlRecord term_rec_;
   std::string what_str_; // keeps copy of what() so that c_str() works
 
   // PlTerm string_term() const; // TODO: revive this

--- a/pl2cpp2.doc
+++ b/pl2cpp2.doc
@@ -1906,7 +1906,7 @@ See PL_unregister_atom().
 See PL_blob_data().
 \end{description}
 
-\section{Classes for the recorded database: PlRecordRaw and PlRecordExternalCopy}
+\section{Classes for the recorded database: PlRecord and PlRecordExternalCopy}
 \label{sec:cpp2-plrecord}
 
 The
@@ -1918,10 +1918,10 @@ Currently, the interface to \jargon{internal records} requires that
 the programmer explicitly call the dupicate() and erase() methods - in
 future, it is intended that this will be done automatically by a new
 \ctype{PlRecord} class, so that the internal records behave like
-"smart pointers"; in the meantime, the \ctype{PlRecordRaw} provides a
+"smart pointers"; in the meantime, the \ctype{PlRecord} provides a
 trivial wrapper around the various recorded database functions.
 
-The class \ctype{PlRecordRaw} supports the following methods:
+The class \ctype{PlRecord} supports the following methods:
 \begin{description}
    \cfunction{}{PlRecord}{PlTerm} Constructor.
    \cfunction{}{PlRecord}{PlRecord} Copy and move
@@ -1932,10 +1932,33 @@ The class \ctype{PlRecordRaw} supports the following methods:
    \cfunction{void}{erase}{} - decrements the reference count of the
    record and deletes it if the count goes to zero, using PL_erase().
    It is safe to do this multiple times on the same
-   \ctype{PlRecordRaw} object.
+   \ctype{PlRecord} object.
    \cfunction{PlRecord}{duplicate}{} - increments the reference count
    of the record, using PL_duplicate_record().
 \end{description}
+
+The class \ctype{PlRecord} provides direct access to the reference
+counting aspects of the recorded term (through the duplicate() and
+erase() methods), but does \emph{not} connect these with C++'s copy
+constructor, assignment operator, or destructor. If the recorded
+term is encapsulated within an object, then the containing object
+can use the duplicate() and erase() methods in its copy and
+move constructors and assignment operators (and the erase() method
+in the destructor).\footnote{The copy constructor and assignment use
+the duplicate() method; the move constructor and assignment use
+the duplicate() method to assign to the destination and the erase()
+method on the source; and the destructor uses erase().}
+
+Alternatively, the \ctype{std::shared_ptr} or \ctype{std::unique_ptr}
+can be used with the supplied \ctype{PlrecordDeleter}, which calls the
+erase() method when the \ctype{shared_ptr} reference count goes to
+zero or when the \ctype{unique_ptr} goes out of scope.
+
+For example:
+\begin{code}
+std::shared_ptr<PlRecord> r(new PlRecord(t.record()), PlRecordDeleter());
+assert(t.unify_term(r->term()));
+\end{code}
 
 The class \ctype{PlRecordExternalCopy} keeps the \jargon{external record}
 as an uninterpreted string. It supports the following methods.
@@ -2573,6 +2596,21 @@ in the future. Currently, to ensure that the exception term has a
 sufficient lifetime, it is serialized using PL_record_external(). In
 future, if this proves unnecessary, the term will be stored as-is.
 The API will not change if this implementation detail changes.
+
+
+\section{Conclusions (version 2)}
+\label{sec:cpp2-conclusions}
+
+In this document, we presented a high-level interface to Prolog
+exploiting automatic type-conversion and exception-handling defined in
+C++.
+
+Programming using this interface is much more natural and requires only
+little extra resources in terms of time and memory.
+
+Especially the smooth integration between C++ and Prolog exceptions
+reduce the coding effort for type checking and reporting in foreign
+predicates.
 
 
 \section{Conclusions (version 2)}

--- a/test_cpp.cpp
+++ b/test_cpp.cpp
@@ -1158,3 +1158,22 @@ PREDICATE(throw_permission_error_cpp, 3)
 PREDICATE(throw_resource_error_cpp, 1)
 { throw PlResourceError(A1.as_string().c_str());
 }
+
+PREDICATE(ten, 10)
+{ PlCheckFail(A1.unify_term(PlTerm_atom(PlAtom("one"))));
+  PlCheckFail(A2.unify_atom(PlAtom("two")));
+  PlCheckFail(A3.unify_atom("three"));
+  PlCheckFail(A4.unify_integer(4));
+  PlCheckFail(A5.unify_float(5.0));
+  PlCheckFail(A6.unify_string("six"));
+  PlCheckFail(A7.unify_functor(PlFunctor("seven", 1)));
+  PlCheckFail(A7[1].unify_string("SEVEN")); 
+  PlCheckFail(A8.unify_nil());
+  PlCheckFail(A9.unify_bool(true));
+  PlTerm_var hd;
+  PlTerm_var tl;
+  PlCheckFail(A10.unify_list(hd, tl));
+  PlCheckFail(hd.unify_atom("hd"));
+  PlCheckFail(tl.unify_nil());
+  return true;
+}

--- a/test_cpp.pl
+++ b/test_cpp.pl
@@ -689,6 +689,11 @@ test(get_atom, error(type_error(atom,123))) :-
 test(get_atom, error(type_error(atom,foo(bar)))) :-
     get_atom_ex(foo(bar), _A).
 
+test(ten,
+     [[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10] ==
+      [one, two, three, 4, 5.0, "six", seven("SEVEN"), [], true, [hd]]]) :-
+    ten(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10).
+
 % TODO:
 % test this (https://swi-prolog.discourse.group/t/cpp2-exceptions/6040/61):
 %


### PR DESCRIPTION
These are needed by rocksdb4pl.cpp