### PR TITLE
Simplify blob interface (PlBlob)

### DIFF
--- a/SWI-cpp2-plx.h
+++ b/SWI-cpp2-plx.h
@@ -198,6 +198,11 @@ PLX_ASIS(bool                    , get_nil                         , (term_t l),
 [[deprecated]]
 PLX_ASIS(int                     , get_term_value                  , (term_t t, term_value_t *v), (t, v))
 PLX_ASIS(char *                  , quote                           , (int chr, const char *data), (chr, data))
+// See the definition of PL_for_dict - return code determined by func:
+PLX_ASIS(int                     , for_dict                        , (term_t dict,
+                                                                      int (*func)(term_t key, term_t value, void *closure),
+                                                                      void *closure, int flags),
+                                                                     (dict, func, closure, flags))
 PLX_ASIS(int                     , term_type                       , (term_t t), (t))
 PLX_ASIS(bool                    , is_variable                     , (term_t t), (t))
 PLX_ASIS(bool                    , is_ground                       , (term_t t), (t))
@@ -235,6 +240,9 @@ PLX_EXCE(int                     , put_list                        , (term_t l),
 PLX_EXCE(int                     , put_nil                         , (term_t l), (l))
 PLX_EXCE(int                     , put_term                        , (term_t t1, term_t t2), (t1, t2))
 PLX_EXCE(int                     , put_dict                        , (term_t t, atom_t tag, size_t len, const atom_t *keys, term_t values), (t, tag, len, keys, values))
+// TODO:
+//    PL_EXPORT(atom_t)	_PL_cons_small_int(int64_t v); // 0 return code means not a small int
+//    PL_EXPORT(void)		_PL_unregister_keys(size_t len, atom_t *keys);
 // (skipped):: int PL_cons_functor(term_t h, functor_t f, ...) WUNUSED;
 PLX_EXCE(int                     , cons_functor_v                  , (term_t h, functor_t fd, term_t a0), (h, fd, a0))
 PLX_EXCE(int                     , cons_list                       , (term_t l, term_t h, term_t t), (l, h, t))
@@ -340,7 +348,9 @@ PLX_WRAP(atom_t                  , new_blob                        , (void *blob
 PLX_EXCE(int                     , put_blob                        , (term_t t, void *blob, size_t len, PL_blob_t *type), (t, blob, len, type))
 PLX_WRAP(int                     , get_blob                        , (term_t t, void **blob, size_t *len, PL_blob_t **type), (t, blob, len, type))
 PLX_ASIS(void*                   , blob_data                       , (atom_t a, size_t *len, struct PL_blob_t **type), (a, len, type))
-PLX_VOID(void                    , register_blob_type              , (PL_blob_t *type), (type))
+PLX_ASIS(int                     , free_blob                       , (atom_t blob), (blob));
+// Should not call PL_register_blob_type, so it's not defined:
+// PLX_VOID(void                 , register_blob_type              , (PL_blob_t *type), (type))
 PLX_ASIS(PL_blob_t*              , find_blob_type                  , (const char* name), (name))
 PLX_ASIS(bool                    , unregister_blob_type            , (PL_blob_t *type), (type))
 

--- a/SWI-cpp2.cpp
+++ b/SWI-cpp2.cpp
@@ -247,7 +247,9 @@ bool PlBlob::write(IOSTREAM *s, int flags) const
     if ( !rc )
       return false;
   }
-  return Sfprintf(s, ")") >= 0;
+  if ( Sfprintf(s, ")") < 0 )
+    return false;
+  return true;
 }
 
 _SWI_CPP2_CPP_inline

--- a/pl2cpp2.doc
+++ b/pl2cpp2.doc
@@ -144,7 +144,7 @@ More specifically:
     is_null(), not_null(), reset(),
     and \cfuncref{reset}{v}, plus the constant \const{null}.}
   \item
-    A convenience class \ctype{PlForeignContextPtr<\emph{ContextType}>}
+    A convenience function PlControl::context_unique_ptr<ContextType>()
     has been added, to simplify dynamic memory allocation in
     non-deterministic predicates.
   \item
@@ -2713,14 +2713,18 @@ Non-deterministic predicates are defined using
 \cfuncref{PREDICATE_NONDET}{plname, cname, arity} or
 \cfuncref{NAMED_PREDICATE_NONDET}{plname, cname, arity}.
 
-A non-deterministic predicate returns a "context", which is passed to a
-a subsequent retry. Typically, this context is allocated on the first
+A non-deterministic predicate returns a "context", which is passed to
+a subsequent retry.  Typically, this context is allocated on the first
 call to the predicate and freed when the predicate either fails or
-does its last successful return. To simplify this, a template helper class
-\ctype{PlForeignContextPtr<\emph{ContextType}>} provides a "smart
-pointer" that frees the context on normal return or an exception;
-if PlForeignContextPtr$<$ContextType$>$::keep()
-is called, the pointer isn't freed on return or exception.
+does its last successful return (the context is \const{nullptr} on the
+first call). To simplify this, a template helper function
+PlControl::context_unique_ptr<ContextType>() provides a "smart
+pointer" that frees the context on normal return or an exception; when
+used with PL_retry_address(), the context's
+std:unique_ptr<ContextType>::release() is used to pass the context
+to Prolog for the next retry, and to prevent the context
+from being freed. If the predicate is called with \const{PL_PRUNE},
+the normal \exam{return true} will implicitly free the context.
 
 The skeleton for a typical non-deterministic predicate is:
 
@@ -2728,10 +2732,11 @@ The skeleton for a typical non-deterministic predicate is:
 struct PredContext { ... }; // The "context" for retries
 
 PREDICATE_NONDET(pred, <arity>)
-{ PlForeignContextPtr<PredContext> ctxt(handle);
+{
+  auto ctxt = handle.context_unique_ptr<PredContext>();
   switch( PL_foreign_control(handle) )
   { case PL_FIRST_CALL:
-      ctxt.set(new PredContext(...));
+      ctxt.reset(new PredContext(...));
       ...
       break;
     case PL_REDO:
@@ -2749,8 +2754,7 @@ PREDICATE_NONDET(pred, <arity>)
 
   ...
 
-  ctxt.keep();
-  PL_retry_address(ctxt.get()); // Succeed with a choice point
+  PL_retry_address(ctxt.release()); // Succeed with a choice point
 }
 \end{code}
 

--- a/pl2cpp2.doc
+++ b/pl2cpp2.doc
@@ -69,7 +69,7 @@ More specifically:
     exception.\footnote{If a ``Plx_'' wrapper is used to call a
     \file{SWI-Prolog.h} function, a Prolog error will have already
     resulted in throwing \ctype{PlException}};
-    `cfuncref{PlCheckFail}{rc} is used to additionally throw
+    PlCheckFail(rc) is used to additionally throw
     \ctype{PlFail}, similar to returning \const{false} from the
     top-level of a foreign predicate.
 \item
@@ -700,24 +700,37 @@ getters for integers.
 The blob API for C++ is not completely general, but is designed to
 make a specific use case easier to write. For other use cases, the
 underlying C API can still be used. The use case is:
+
 \begin{itemize}
 \item The blob contains the foreign object (e.g., contains a
-      pointer to a database connection).
+      pointer to a database connection), plus optionally some
+      other data.
 \item The blob is created by a predicate that makes the foreign
-      object and stores it (or a pointer to it) within the blob.
-      For example, makes a connection to a database or compiles
+      object and stores it (or a pointer to it) within the blob -
+      for example, making a connection to a database or compiling
       a regular expression into an internal form.
-\item Optionally, there is a predicate that deletes the foreign object.
+\item Optionally, there is a predicate that deletes the foreign object,
+      such as a file or database connection close().
 \item The blob will not be subclassed.
 \item The blob is defined as a subclass of \ctype{PlBlob}, which
       provides a number of fields and methods, of which a few
       can be overridden in the blob (notably: write_fields(),
-      compare_fields(), and the destructor).
+      compare_fields(), save(), load(), and the destructor).
+\item The blob must have a default constructor that sets all the
+      fields to appropriate initial values.\footnote{This is
+      used by the load() method, which by default throws an error.}
 \item The blob's constructor throws an exception and cleans up
-      any resources if it cannot create the blob.
+      any resources if it cannot create the blob.\footnote{This
+      is not a strong requirement, but
+      the code is simpler if this style is used.}
 \item The foreign object can be deleted when the blob is deleted.
+      That is, the foreign object is created using the \const{new}
+      operator and passes ownership to the blob.
 \item The blob's allocation is controlled by Prolog and its
       destructor is envoked when the blob is garbage collected.
+      Optionally, the predicate that deletes the foreign object
+      deletes the foreign object and the Prolog garbage collector
+      only frees the blob.
 \end{itemize}
 
 A Prolog blob consists of five parts:
@@ -732,22 +745,20 @@ A Prolog blob consists of five parts:
       file-like object, these could be read, write, seek, etc.).
 \end{itemize}
 
-For the \ctype{PL_blob_t} structure, this API provides a set of
+For the \ctype{PL_blob_t} structure, the C++ API provides a set of
 template functions that allow easily setting up the callbacks, and
-allow defining the corresonding methods int he blob "contents" class.
-The C interface allows defaulting all of the callbacks; however, the
-C++ API for blobs provides suitable callbacks for all of them, so
-usually the programmer will specify all the template callbacks.
+defining the corresonding methods in the blob "contents" class.
+The C interface allows more flexibility by allosing some of the
+callbacks to default; however, the C++ API for blobs provides suitable
+callbacks for all of them, so usually the programmer will specify all
+the template callbacks using the
+PL_BLOB_DEFINITION(blob_class,blob_name) macro.
 
 For the data, which is subclassed from \ctype{PlBlob}, the programmer
 defines the various fields, a constructor that initializes them, and a
 destructor.  Optionally, methods can be defined for one of more of
-blob compare_fields(), write_fields(),
-save(), load(). The acquire() and
-release() callbacks should normally be allowed to default
-to what is defined in \ctype{PlBlob}; and the default
-write() and compare() callbacks call
-write_fields() and compare_fields().
+blob compare_fields(), write_fields(), save(), load().
+More details on these are given later.
 
 There is a mismatch between how Prolog does memory management (and
 garbage collection) and how C++ does it. In particular, Prolog assumes
@@ -759,10 +770,10 @@ created using \const{PL_BLOB_NOCOPY} and manages memory using a
 \ctype{std::unique_ptr}.
 
 The C blob interface has a flag that determines how memory is managed:
-\const{PL_BLOB_NOCOPY}. If this is set, Prolog does not do a call to
-free() when the blob is garbage collected; instead, it
-assumes that the blob's release() function will free the
-memory.
+\const{PL_BLOB_NOCOPY}. The PL_BLOB_DEFINITION() macro sets this, so
+Prolog does not do a call to free() when the blob is garbage
+collected; instead, it lets the blob's release() free the memory,
+which is done by calling the C++ destructor.
 
 The C++ API for blobs only supports blobs with
 \const{PL_BLOB_NOCOPY}.\footnote{The API can probably also support
@@ -772,236 +783,361 @@ point in setting this flag for non-text blobs.}
 \subsubsection{How to define a blob using C++}
 \label{sec:cpp2-blobs-howto}
 
-TL;DR: Use PL_BLOB_NOCOPY (or an extra level of indirection) and the
-default \ctype{PlBlob} wrappers; no copy constructor, move
-constructor, or assignment operator; create blob with
-\exam{make_unique}, use \exam{unique_ptr::release}, do \exam{delete}
-in the "release" function. Optionally, define one or more of
-compare_fields(), write_fields(),
-save(), load() methods.
+TL;DR: Use PL_BLOB_DEFINITION() to define the blob with the flag
+\const{PL_BLOB_NOCOPY} and the default \ctype{PlBlob} wrappers; define
+your struct as a subclass of \ctype{PlBlob} with no copy constructor,
+move constructor, or assignment operator; create blob using
+exam{std::unique_ptr<PlBlob>(new ...)}, call PlTerm::unify_blob().
+Optionally, define one or more of: compare_fields(), write_fields(),
+save(), load() methods (these are described after the sample code).
+
+\subsubsection{The life of a PlBlob}
+\label{sec:cpp2-blobs-life}
+
+In this section, the blob is of type \ctype{MyBlob}, a subclass
+of \ctype{PlBlob}.
+
+A blob is typically created by calling a predicate that does
+the following:
+\begin{itemize}
+\item Creates the blob using
+      \exam{auto ref = std::unique_ptr<PlBlob>(new MyBlob>(...))}
+      (std::make_unique() can't be used because it returns type
+      \ctype{std::unique_ptr<MyBlob>} but PlTerm::unify_blob() requires a
+      \ctype{std::unique_ptr<PlBlob>} and C++'s type inferencing can't figure
+      out that this is a covariant type.
+
+\item Calls PlTerm::unify_blob(ref), using PlCheckFail() to throw
+      an exception if it fails.
+      This, in turn, calls:
+      \begin{itemize}
+      \item PlBlobV<MyBlob>acquire(), which calls
+      \item MyBlob::acquire(), which sets \arg{MyBlob::symbol_}.
+      \arg{MyBlob::symbol_} is usually accessed using the
+      method MyBlob::symbol_term().
+      If this all succeeds, PlTerm::unify_blob(ref) calls
+      \exam{ref.release()} to pass ownership to the Prolog blob.\footnote{If
+      you wish to use std::make_unique<MyBlob>(), you could instead do:
+      \begin{code}
+      auto ref = std::make_unique<MyBlob>(...);
+         ... // code that accesses fields in *ref
+      std::unique_ptr<PlBlob> refb(ref.release()); // transfer ownership of ptr
+         // from here on, can't access fields in *ref
+      return A2.unify_blob(refb);
+      \end{code} }
+      \end{itemize}
+\end{itemize}
+
+At this point, the blob is owned by Prolog and will be freed by
+its atom garbage collector.
+
+Whenever a predicate is called with the blob as an argument (e.g.,
+as \arg{A1}), the blob can be accessed by
+\exam{PlBlobv<MyBlob>::cast_check(A1.as_atom())}.
+
+Within a method, the Prolog blob can be accessed as a term (e.g., for
+constructing an error term) using the method MyBlob::symbol_term().
+This field is initialized by the call to PlTerm::unify_blob(); if
+MyBlob::symbol_term() is called before a successful call to
+PlTerm::unify_blob(), MyBlob::symbol_term() returns a
+\ctype{PlTerm_var}.
+
+When the atom garbage collector runs, it frees the blob by first
+calling the release() callback, which does \const{delete}, which calls
+the destructor MyBlob::~MyBlob(). Note that C++ destructors are not
+supposed to raise exception; they also should not cause a Prolog
+error, which could cause deadlock unless the real work is done in
+another thread.
+
+Often it is desired to release the resources before the garbage
+collector runs. To do this, the programmer can provide a "close"
+predicate which is the inverse of the "open" predicate that created
+the blob. This typically has the same logic as the destructor, except
+that it can raise a Prolog error.
+
+\subsubsection{C++ exceptions and blobs}
+\label{sec:cpp2-blobs-exceptions
+
+When a blob is used in the context of a PREDICATE() macro, it can
+raise a C++ exception (\ctype{PlFail} or \PlException}) and the
+PREDICATE() code will convert it to the appropriate Prolog failure or
+error; memory allocation exceptions are also handled.
+
+Blobs also have callbacks, which can run outside the context of
+a PREDICATE(). Their exception handling is as follows:
+
+\begin{itemize}
+\item compare_fields(), which is called from PlBlobV<MyBlob>::compare()
+      should not throw an exception. A Prolog error won't work as it uses "raw
+      pointers" and thus a GC or stack shift triggered by creating the
+      exception will upset the system.
+\item write_fields(), which is called from PlBlobV<MyBlob>::write()
+      can throw an exception, just like code inside a PREDICATE().
+      In particular, you can wrap calls to Sfprintf() in PlCheckFail().
+\item save() can throw a C++ exception, include PlFail().
+\item load() can throw a C++ exception, which is converted to
+      a return value of\tag{PlAtom::null}, which is interpreted by
+      Prolog failure.
+\end{itemize}
+
+\subsubsection{Sample PlBlob code}
+\label{sec:cpp2-blobs-sample-code}
 
 Here is minimal sample code for creating a blob that owns a connection
 to a database. It has a single field (\exam{connection}) and
 defines compare_fields() and write_fields().
 Note that you must add the boilerplate definition for the virtual
 method blob_size_(), using the convenience macros
-\cfuncref{PL_BLOB_DEFINITION}{blob_class,blob_name} and
-PL_BLOB_SIZE().
+PL_BLOB_DEFINITION(blob_class,blob_name) and
+\const{PL_BLOB_SIZE}.
 
 \begin{code}
-struct dbref;
+struct MyBlob;
 
-static PL_blob_t my_blob = PL_BLOB_DEFINITION(dbref, "my_blob");
+static PL_blob_t my_blob = PL_BLOB_DEFINITION(MyBlob, "my_blob");
 
-struct dbref : public PlBlob
-{ my_connection *connection = nullptr;
+struct MyBlob : public PlBlob
+{ std::unique_ptr<MyConnection> connection;
+  std::string name_; // Used for error terms
 
-  explicit dbref()
-    : PlBlob(&my_blob)
-  { }
+  explicit MyBlob()
+    : PlBlob(&my_blob) { }
 
-  ~dbref()
-  { if ( connection )
-    { // This is similar to close_my_blob/1, except there's no check
-      // for an error -- there's nothing we can do on an error because
-      // throwing a C++ exception inside of C code will cause a
-      // runtime error.
-      (void)connection->close();
-    }
+  explicit MyBlob(const std::string& connection_name)
+    : PlBlob(&my_blob),
+      connection(std::make_unique<MyConnection>(connection_name)),
+      name_(connection_name)
+  { if ( !connection->open() )
+      throw MyBlobError("my_blob_open_error");
   }
 
   PL_BLOB_SIZE
 
+  ~MyBlob() noexcept
+  { if ( !close() )
+      Sdprintf("Close MyBlob failed: %s", name_.c_str()); // Can't use PL_warning()
+  }
+
+  bool close() noexcept
+  { if ( !connection )
+      return true;
+    bool rc = connection->close();
+    connection.reset(); // Can be omitted, leaving deletion to ~MyBlob()
+    return rc;
+  }
+
+  PlException MyBlobError(const char* error) const
+  { return PlGeneralError(PlCompound(error, PlTermv(symbol_term())));
+  }
+
   int compare_fields(const PlBlob* _b_data) const override
-  { auto b_data = static_cast<const dbref*>(_b_data); // See note about cast
-    if ( connection && b_data->connection )
-      return connection->name.compare(b_data->connection->name);
-    return connection ? 1 : b_data->connection ? -1 : 0;
+  { auto b_data = static_cast<const MyBlob*>(_b_data); // See note about cast
+    return name_.compare(b_data->name_);
   }
 
   bool write_fields(IOSTREAM *s, int flags) const override
-  { if ( connection )
-      return Sfprintf(s, ",name=%s", connection->name.c_str());
+  { if ( !Sfprintf(s, ",name=%s", name_.c_str()) )
+      return false;
+    if ( !connection )
+      return Sfprintf(s, ",closed");
     return true;
   }
 };
 
-// %! create_my_blob(+Options, -MyBlob) is semidet.
+// %! create_my_blob(+Name: atom, -MyBlob) is semidet.
 PREDICATE(create_my_blob, 2)
-{ // Allocating the blob uses unique_ptr<dbref> so that it'll be
+{ // Allocating the blob uses std::unique_ptr<MyBlob> so that it'll be
   // deleted if an error happens - the auto-deletion is disabled by
   // ref.release() before returning success.
 
-  auto ref = std::make_unique<dbref>();
-
-  // ... fill in the fields of *ref from options in A1  ...
-
-  if ( !ref->connection->open() )
-    throw PlGeneralError(PlCompound("my_blob_error", PlTermv(ref->symbol_term())));
-  PlCheckFail(A2.unify_blob(ref.get()));
-  (void)ref.release();
-  return true;
+  auto ref = std::unique_ptr<PlBlob>(new MyBlob(A1.as_atom().as_string()));
+  return A2.unify_blob(&ref);
 }
 
 // %! close_my_blob(+MyBlob) is det.
 // % Close the connection, silently succeeding if is already
 // % closed; throw an exception if something goes wrong.
 PREDICATE(close_my_blob, 1)
-{ auto ref = PlBlobV<dbref>::cast_check<dbref>(A1.as_atom());
-  auto c = ref->connection;
-  ref->connection = nullptr;
-  if ( c )
-  { bool rc = c->close();
-    delete c;
-    if ( !rc )
-      throw PlGeneralError(PlCompound("my_blob_error",
-				      PlTermv(ref->symbol_term())));
-  }
+{ auto ref = PlBlobV<MyBlob>::cast_ex(A1, my_blob);
+  if ( !ref->close() )
+    throw ref->MyBlobError("my_blob_close_error");
   return true;
 }
 \end{code}
 
-Explanation of the \ctype{my_blob} structure, which is usually
-created using \exam{PL_BLOB_DEFINITION(blob_class,blob_name)}.
-It should be declared outside the \ctype{PlBlob} class and should
-not be marked \exam{const} - otherwise, a runtime error can
-occur.\footnote{The cause of the runtime error is not clear, but
-possibly has to do with the order of initializing globals.}
+\subsubsection{Discussion of the sample PlBlob code}
+\label{sec:cpp2-blobs-sample-code-discussion}
 
 \begin{itemize}
 
-\item The \exam{magic}, \exam{flags}, and \exam{name} flags are required.
+\item PL_BLOB_DEFINITION(MyBlob, "my_blob") creates a
+      \ctype{PL_blob_t} structure with the wrapper functions and flags
+      set to \const{PL_BLOB_NOCOPY}.
+      It should be declared outside the \ctype{PlBlob} class and should
+      not be marked \exam{const} - otherwise, a runtime error can
+      occur.\footnote{The cause of the runtime error is not clear, but
+      possibly has to do with the order of initializing globals, which
+      is unspecified for C++.}
 
-\item The \exam{release} and \exam{acquire} fields are required. The
-      defaults given will normally suffice (see more on this in the
-      definition of \exam{dbref}). These can be extended by overriding
-      PlBlob::acquire2() or PlBlob::release2().
+\item The \ctype{MyBlob} struct is a subclass of \ctype{PlBlob}.
+      See below for a discussion of the default behaviors.
 
-\item The default save() and load() provide a
-      implementation that throws an error on an attempt to
-      save the blob (e.g., by using \qsave_program/[1,2]). If they are
-      omitted, the defaults for save() and
-      load() are used, which save the internal form of the
-      blob, which is probably not what you want. If you wish to define
-      your own save() and load(), you must also
-      add save() and load() methods to
-      \ctype{dbref}.
+  \begin{itemize}
 
-\item The default compare() does a pointer
-      comparison. You can define a compare_fields();
-      if it returns 0 (equal), the pointers are compared.
-      If no compare() is specified in the definition
-      of the blob (\ctype{PL_blob_t}), the default
-      is a bit-wise comparison.
-      The compare_fields() method receives a pointer to
-      \ctype{PlBob<my_blob>} - it is safe to use
-      \exam{static_cast} to convert this to a pointer to
-      \ctype{my_blob} because Prolog guarantees that the
-      compare_fields() method will only be called
-      if two blobs are of the same type.
+  \item \ctype{MyBlob} contains a pointer to a \ctype{MyConnection} object
+      and keeps a copy of the connection's name. The \ctype{MyConnection}
+      object is handled by a \ctype{std::unique_ptr} smart pointer, so that
+      it is automatically freed when the \ctype{MyBlob} object is freed.
 
-\item The default write() outputs something of the
-      form \exam{<my_blob>(0x1234)}, giving the blob type name
-      and its address. You can define write_fields(),
-      to provide additional information - in the example code,
-      the connection name is output (note the leading ",").
+  \item A default constructor is defined - this is needed for the
+      load() and save() methods; it invokes the \ctype{PlBlob}
+      constructor.
 
-\end{itemize}
+  \item The \ctype{MyBlob} class must not provide a copy or move
+        constructor, nor an assignment operator (PlBlob defines these
+        as deleted, so if you try to use one of these, you will get a
+        compile-time error).
 
-Explanation of the \ctype{dbref} structure:
+  \item \ctype{PlBlob}'s constructor sets \exam{blob_t_} to a pointer
+        to the \ctype{my_blob} definition.  This is used for run-time
+        consistency checking by the various callback functions and for
+        constructing error terms (see PlBlob::symbol_term()).
 
-\begin{itemize}
+  \item \ctype{PlBlob}'s acquire() is called by
+        PlBlobV<MyBlob>::acuire() and fills in the \exam{symbol}
+        field. \ctype{MyBlob} must not override this - it is not a
+        virtual method.
 
-\item \ctype{PlBlob} provides default methods plus a few
-      utility methods and functions:
-      \begin{itemize}
-      \item Copy and move constructors are disabled, as is the
-            assignment operator.
-      \item blob_t_() gets a pointer to the \ctype{PL_blob_t} definition.
-      \item acquire() is used by the default acquire() function;
-            it fills in the \exam{symbol} field. It calls acquire2()
-            for any additional actions.
-      \item acquire2() is called by aquire() to do any additional processing
-            when the blob is first initialized. The default does nothing.
-      \item release2() is called by the blob's release() callback.
-            The default does nothing.
-      \item symbol_not_null() tests whether \exam{symbol} has been set
-            (this will normally be the case, unless the acquire()
-            function hasn't been called as part of the blob creation
-            process).
-      \item symbol_term() Creates a term the contains the blob, for
-            use in error terms. It is always safe to use this; if
-            the symbol hasn't been set, symbol_term() returns a "var" term.
-      \item compare() calls compare_fields() - if that returns 0
-            (equal), then it returns the result of comparing
-            pointers.
-      \item compare_fields() allows extending the comparison function
-            to include class-specific information.
-      \item write() A default implementation that outputs \exam{<my_blob>(ptr)}.
-            It calls write_fields() to allow adding class-specific information.
-      \item write_fields() allows outputting class-specific information.
-            It is given the flags that were passed to PL_write_term() that
-            called write_fields(), with some of the flags removed
-            (such as \exam{PL_WRT_NEWLINE}), so that write_fields() can
-            call PlTerm::write() or PlAtom::write() with the same flags.
-            \emph{Note}: if you use any C++ functions or methods that
-            can throw an exception, you should catch them and return
-            \const{false}.
-      \item save() Generates an error when attempting to save the blob.
-      \item load() generates an error when attemptint to load the blob.
-      \end{itemize}
+  \item PlBlob::symbol_term() Creates a term from the blob, for use in
+        error terms. It is always safe to use this; if the symbol
+        hasn't been set (because acquire() hasn't been called),
+        symbol_term() returns a "var" term.
 
-\item The constructor sets the \ctype{PL_blob_t} value, which is similar
-      to a C++ vtable.
+  \item The MyBlob(connection_name) constructor creates a
+      \ctype{MyConnection} object. If this fails, an exception is
+      thrown. The constructor then calls MyConnection::open() and
+      throws an exception if that fails. (The code would be similar
+      if the constructor for \ctype{MyConnection} also did an open
+      and threw an exception on failure.)
 
-\item The blob_size_() virtual method is abstract; when the blob is defined,
-      it must contain the following, which is used by PlTerm::unify_blob():
+  \item The \const{PL_BLOB_SIZE} is boilerplate that defines a
+      blob_size_() method that is used when the blob is created.
+
+  \item The destructor ~MyBlob() is called when the blob is released
+      by the garbage collector and in turn calls the MyBlob::close(),
+      throwing away the result. If there is an error, a message is
+      printed because there is no other way report the error. For this
+      reason, it is preferred that the program explicitly calls the
+      close_my_blob/1 predicate, which can raise an error. One way of
+      doing this is by using the at_halt/1 hook.
+
+  \item The MyBlob::close() method is called by either the destructor
+      or by the close_my_blob/1 predicate. Because it can be called by
+      the garbage collector, which does not provide the usual
+      environment and which may also be in a different thread, the
+      only Prolog function that can be called is
+      PlAtom::unregister_ref(); and the MyBlob::close() method must
+      not throw an exception.\footnote{It isn't enough to just catch
+      exceptions; for example, if the code does \exam{throw
+      PlUnknownErro("...")}, that will try to create a Prolog term,
+      which will crash because the environment for creating terms is
+      not available.}  Because there is no mechanism for reporting an
+      error, the destructor prints a message on failure (calling
+      PL_warning() would cause a crash).
+
+      PlBlob::close() calls MyConnection::close() and then frees the
+      object.  Error handling is left to the caller because of the
+      possibility that this is called in the context of garbage
+      collection. It is not necessary to free the \ctype{MyConnection}
+      object here - if it is not freed, the
+      \ctype{std::unique_ptr<MyConnection>}'s destructor would free
+      it.
+
+  \item PlBlob::MyBlobError() is a convenience method for creating
+      errror terms.
+
+  \item PlBlob::compare_fields() makes the blob comparison function
+      more deterministic by comparing the name fields; if the names
+      are the same, the comparison will be done by comparing the
+      addresses of the blobs (this is the default behavior for blobs).
+      PlBlob::compare_fields() is called by
+      PlBlobV<PlBlob>::compare(), which provides the default
+      comparison if PlBlob::compare_fields() returns \const{0}
+      ("equal").
+
+      The \arg{_b_data} argument is of type \ctype{const PlBlob*} -
+      this is cast to \ctype{const MyBlob*} using a
+      \const{static_cast}.  This is safe because Prolog guarantees
+      that PlBlobV<PlBlob>::compare() will only be called if both
+      blobs are of the same type.
+
+  \item PlBlob::write_fields() outputs the name and the status of the
+      connection, in addition to the default of outputting the blob
+      type and its address. This is for illustrative purposes only; an
+      alternative is to have a my_blob_properties/2 predicate to
+      provide the information.
+
+      The \arg{flags} argument is the same as given to
+      PlBlobV<PlBlob>::write(), which is a bitwise \emph{or} of zero
+      or more of the \const{PL_WRT_*} flags that were passed in to the
+      caling PL_write_term() (defined in \file{SWI-Prolog.h}). The
+      \arg{flags} do not have the \const{PL_WRT_NEWLINE} bit set, so
+      it is safe to call PlTerm::write() and there is no need for
+      writing a trailing newline.
+
+     If anything in PlBlob::write_fields() throws a C++ exception, it
+     will be caught by the calling PlBlobV<PlBlob>::write() and
+     handled appropriately.
+
+  \item PlBlob::save() and PlBlob::load() are not defined, so the
+      defaults are used - they throw an error on an attempt to save
+      the blob (e.g., by using \qsave_program/[1,2]).\footnote{If
+      these weren't specified, the defaults would save the internal
+      form of the blob, which is probably not what you want.}
+
+  \end{itemize}
+
+\item create_my_blob/2 predicate:
+
+  \begin{itemize}
+
+  \item \exam{std::unique_ptr<PlBlob>()} creates a MyBlob that is
+      deleted when it goes out of scope. If an exception occurs
+      between the creation of the blob or if the call to unify_blob()
+      fails, the pointer will be automatically freed (and the
+      \ctype{MyBlob} destructor will be called).
+
+      If PlTerm::unify_blob() is called with a pointer to a
+      \ctype{std::unique_ptr}, it takes ownership of the object by
+      calling std::unique_ptr<PlBlob>::release().  This sets \arg{ref}
+      to \const{nullptr}, so any attempt to use \arg{ref} after a
+      successful call to PlTerm::unify_blob() will be an error.
+
+      If you wish to create a \ctype{MyBlob} object instead of a
+      \ctype{PlBlob} object, a slightly different form is used:
       \begin{code}
-      virtual size_t blob_size_() const override { return sizeof *this; }
+      auto ref = std::make_unique<MyBlob>(...);
+        ...
+      std::unique_ptr<PlBlob> refb(ref.release());
+      PlCheckFail(A2.unify_blob(&refb);
+      return true;
       \end{code}
 
-\item The constructor must initialize fields so that the destructor
-      can determine whether to delete them or not. Typically, this is
-      done by setting pointers to \const{nullptr} or by setting a
-      flag.
+  \end{itemize}
 
-\item The destructor is called by release(), assuming you've
-      set \exam{my_blob::release} to \exam{blob_release<my_blob>}.
+\item close_my_blob/1 predicate:
 
-\end{itemize}
+  \begin{itemize}
 
-Explanation of create_my_blob/2:
+  \item The argument is turned into a \ctype{MyBlob} pointer using the
+      PlBlobV<MyBlob>::cast_ex() function, which will throw a
+      \const{type_error} if the argument isn't a blob of the expected
+      type.
 
-\begin{itemize}
+  \item The MyBlob::close() method is called - if it fails,
+      a Prolog error is thrown.
 
-\item \exam{std::make_unique<dbref>()} creates a
-      \ctype{std::unique_ptr<dbref>} that is deleted when it goes
-      out of scope. If an exception occurs between the creation of the
-      blob (as a \ctype{std::unique_ptr<dbref>}) and the call to
-      unify_blob(), the pointer will be freed (and the
-      \ctype{MyBlob} destructor will be called.
-
-\item The exception term contains the blob, using
-      \exam{ref->symbol_term()}.
-
-\item \exam{ref.release()} prevents the pointer from being
-      automatically deleted; it is now "owned" by Prolog and is
-      deleted in the release() function (which is defined
-      in \ctype{PlBlob}).
-
-\end{itemize}
-
-Explanation of close_my_blob/1:
-
-\begin{itemize}
-
-\item This code is similar to the destructor for \ctype{dbref},
-      except it throws an error if something goes wrong during the
-      "close".
-
-\item Other predicates that use the blob access the
-      blob from the arguments the same way, namely
-      \exam{PlBlobV<dbref>::cast_check<dbref>(A1.as_atom())}.
+  \end{itemize}
 
 \end{itemize}
 
@@ -1239,7 +1375,7 @@ true.
 Average = 10.333333333333334.
 \end{code}
 
-\section{Rational for changes from version 1 (version 2)}
+\section{Rationale for changes from version 1 (version 2)}
 \label{sec:cpp2-rationale}
 
 \subsection{Implicit constructors and conversion operators}
@@ -1716,8 +1852,11 @@ See also \secref{cpp2-foreign-frame}.
     \nodescription
     \cfunction{bool}{PlTerm::unify_nil}{}
     \nodescription
-    \cfunction{bool}{PlTerm::unify_blob}{PlBlob<blob_t>* blob}
+    \cfunction{bool}{PlTerm::unify_blob}{PlBlob* blob}
     \nodescription
+    \cfunction{bool}{PlTerm::unify_blob}{std::unique_ptr<PlBlob> blob}
+    Does a call to PL_unify_blob() and, if successful, calls
+    std::unique_ptr<PlBlob>::release() to pass ownership to the Prolog blob.
     \cfunction{bool}{PlTerm::unify_blob}{void *blob, size_t len, PL_blob_t *type}
     \nodescription
     \cfunction{bool}{PlTerm::unify_chars}{int flags, size_t len, const char *s}
@@ -2278,7 +2417,7 @@ method on the source; and the destructor uses erase().}
 Alternatively, the \ctype{std::shared_ptr} or \ctype{std::unique_ptr}
 can be used with the supplied \ctype{PlrecordDeleter}, which calls the
 erase() method when the \ctype{shared_ptr} reference count goes to
-zero or when the \ctype{unique_ptr} goes out of scope.
+zero or when the \ctype{std::unique_ptr} goes out of scope.
 
 For example:
 \begin{code}

--- a/test_cpp.cpp
+++ b/test_cpp.cpp
@@ -778,11 +778,11 @@ struct RangeCtxt
 
 PREDICATE_NONDET(range_cpp, 3)
 { auto t_low = A1, t_high = A2, t_result = A3;
-  PlForeignContextPtr<RangeCtxt> ctxt(handle);
+  auto ctxt = handle.context_unique_ptr<RangeCtxt>();
 
   switch( handle.foreign_control() )
   { case PL_FIRST_CALL:
-      ctxt.set(new RangeCtxt(t_low.as_long(), t_high.as_long()));
+      ctxt.reset(new RangeCtxt(t_low.as_long(), t_high.as_long()));
       break;
     case PL_REDO:
       break;
@@ -802,7 +802,7 @@ PREDICATE_NONDET(range_cpp, 3)
   { return true; // Last result: succeed without a choice point
   }
 
-  PL_retry_address(ctxt.keep()); // Succeed with a choice point
+  PL_retry_address(ctxt.release()); // Succeed with a choice point
 }
 
 
@@ -993,7 +993,7 @@ int_info_(const std::string name, PlTerm result, IntInfoCtxt *ctxt)
 }
 
 PREDICATE_NONDET(int_info, 2)
-{ PlForeignContextPtr<IntInfoCtxt> ctxt(handle);
+{ auto ctxt = handle.context_unique_ptr<IntInfoCtxt>();
 
   // When called with PL_PRUNED, A1 is not bound; therefore, we need
   // to do the switch on PL_foreign_control(handle) before checking
@@ -1004,7 +1004,7 @@ PREDICATE_NONDET(int_info, 2)
   { case PL_FIRST_CALL:
       if ( !A1.is_variable() ) // int_info is a map, so unique on lookup
 	return int_info_(A1.as_string(), A2, ctxt.get());
-      ctxt.set(new IntInfoCtxt());
+      ctxt.reset(new IntInfoCtxt());
       break;
     case PL_REDO:
       break;
@@ -1023,7 +1023,7 @@ PREDICATE_NONDET(int_info, 2)
       if ( ctxt->it == ctxt->int_info->cend() )
       { return true; // Last result: no choice point
       }
-      PL_retry_address(ctxt.keep()); // Succeed with choice point
+      PL_retry_address(ctxt.release()); // Succeed with choice point
     }
     ctxt->it++;
   }


### PR DESCRIPTION
- Add PlTerm::unify_blob for unique_ptr
- Add try/catch to blob callbacks
- Improve documentation of PlBlob Rename some implementation functions to more meaninful names Fix inverted condition test (zero vs non-zero return code) Move some code from SWI-cpp2.h to SWI-cpp2.cpp
Add PREDICATE_CATCH macro to remove copy&paste code duplication Rename some example classes to improve the documentation Improve some garbage collection tests for blobs
Update with changes from swipl v9.1.12