### PR TITLE
ENHANCED: remove unnecessary "const ...&" from parameters; deprecate some dubious functions

### DIFF
--- a/SWI-cpp2.cpp
+++ b/SWI-cpp2.cpp
@@ -124,6 +124,33 @@ PlTerm::get_nchars(unsigned int flags) const
   return std::string(s, len);
 }
 
+#define _MUST_BE_TYPE(must_be_name, is_test, type_name)  \
+_SWI_CPP2_CPP_inline \
+void \
+PlTerm::must_be_name() const \
+{ if ( !is_test() ) \
+    throw PlTypeError(type_name, *this); \
+}
+
+_MUST_BE_TYPE(must_be_attvar,         is_attvar,         "attvar")
+_MUST_BE_TYPE(must_be_variable,       is_variable,       "variable")
+_MUST_BE_TYPE(must_be_ground,         is_ground,         "ground")
+_MUST_BE_TYPE(must_be_atom,           is_atom,           "atom")
+_MUST_BE_TYPE(must_be_integer,        is_integer,        "integer")
+_MUST_BE_TYPE(must_be_string,         is_string,         "string")
+_MUST_BE_TYPE(must_be_atom_or_string, is_atom_or_string, "atom or string")
+_MUST_BE_TYPE(must_be_float,          is_float,          "float")
+_MUST_BE_TYPE(must_be_rational,       is_rational,       "rational")
+_MUST_BE_TYPE(must_be_compound,       is_compound,       "compound")
+_MUST_BE_TYPE(must_be_callable,       is_callable,       "callable")
+_MUST_BE_TYPE(must_be_list,           is_list,           "list")
+_MUST_BE_TYPE(must_be_dict,           is_dict,           "dict")
+_MUST_BE_TYPE(must_be_pair,           is_pair,           "pair")
+_MUST_BE_TYPE(must_be_atomic,         is_atomic,         "atomic")
+_MUST_BE_TYPE(must_be_number,         is_number,         "number")
+_MUST_BE_TYPE(must_be_acyclic,        is_acyclic,        "acyclic")
+
+#undef _MUST_BE_TYPE
 
 _SWI_CPP2_CPP_inline
 PlModule

--- a/SWI-cpp2.cpp
+++ b/SWI-cpp2.cpp
@@ -139,7 +139,7 @@ PlGeneralError(PlTerm inside)
 
 _SWI_CPP2_CPP_inline
 PlException
-PlTypeError(const std::string& expected, const PlTerm& actual)
+PlTypeError(const std::string& expected, PlTerm actual)
 { // See PL_type_error()
   return PlGeneralError(PlCompound("type_error",
                                    PlTermv(PlTerm_atom(expected), actual)));
@@ -147,7 +147,7 @@ PlTypeError(const std::string& expected, const PlTerm& actual)
 
 _SWI_CPP2_CPP_inline
 PlException
-PlDomainError(const std::string& expected, const PlTerm& actual)
+PlDomainError(const std::string& expected, PlTerm actual)
 { // See PL_domain_error()
   return PlGeneralError(PlCompound("domain_error",
                                    PlTermv(PlTerm_atom(expected), actual)));
@@ -155,7 +155,7 @@ PlDomainError(const std::string& expected, const PlTerm& actual)
 
 _SWI_CPP2_CPP_inline
 PlException
-PlDomainError(const PlTerm& expected, const PlTerm& actual)
+PlDomainError(PlTerm expected, PlTerm actual)
 { // See PL_domain_error()
   // This is used by
   //    PlDomainError(PlCompound("argv", PlTermv(PlTerm_integer(size_))), ...)
@@ -166,14 +166,14 @@ PlDomainError(const PlTerm& expected, const PlTerm& actual)
 
 _SWI_CPP2_CPP_inline
 PlException
-PlInstantiationError(const PlTerm& t)
+PlInstantiationError(PlTerm t)
 { // See PL_instantiation_error()
   return PlGeneralError(PlCompound("instantiation_error", PlTermv(t)));
 }
 
 _SWI_CPP2_CPP_inline
 PlException
-PlUninstantiationError(const PlTerm& t)
+PlUninstantiationError(PlTerm t)
 { // See PL_uninstantiation_error()
   return PlGeneralError(PlCompound("uninstantiation_error", PlTermv(t)));
 }
@@ -196,7 +196,7 @@ PlExistenceError(const std::string& type, PlTerm actual)
 
 _SWI_CPP2_CPP_inline
 PlException
-PlPermissionError(const std::string& op, const std::string& type, const PlTerm& obj)
+PlPermissionError(const std::string& op, const std::string& type, PlTerm obj)
 { // See: Use PL_permission_error()
   return PlGeneralError(PlCompound("permission_error",
                                    PlTermv(PlTerm_atom(op), PlTerm_atom(type), obj)));
@@ -375,7 +375,7 @@ PlTerm::PlTerm(const PlRecord& r)
 		 *******************************/
 
 _SWI_CPP2_CPP_inline
-PlTerm_tail::PlTerm_tail(const PlTerm& l)
+PlTerm_tail::PlTerm_tail(PlTerm l)
 { if ( l.is_variable() || l.is_list() )
     reset(l.copy_term_ref());
   else
@@ -600,7 +600,7 @@ PlTerm::eq(const std::string& s) const
 
 _SWI_CPP2_CPP_inline
 bool
-PlTerm::eq(const PlAtom& a) const
+PlTerm::eq(PlAtom a) const
 { atom_t v;
 
   if ( Plx_get_atom(unwrap(), &v) )
@@ -674,21 +674,21 @@ PlCompound::PlCompound(const std::wstring& functor, const PlTermv& args)
 		 *******************************/
 
 _SWI_CPP2_CPP_inline
-PlTermv::PlTermv(const PlAtom& a)
+PlTermv::PlTermv(PlAtom a)
   : size_(1),
     a0_(PlTerm_atom(a).unwrap())
 { PlEx<bool>(a0_ != (term_t)0);
 }
 
 _SWI_CPP2_CPP_inline
-PlTermv::PlTermv(const PlTerm& m0)
+PlTermv::PlTermv(PlTerm m0)
   : size_(1),
     a0_(m0.unwrap())
 { // Assume that m0 is valid
 }
 
 _SWI_CPP2_CPP_inline
-PlTermv::PlTermv(const PlTerm& m0, const PlTerm& m1)
+PlTermv::PlTermv(PlTerm m0, PlTerm m1)
   : size_(2),
     a0_(Plx_new_term_refs(2))
 { PlEx<bool>(a0_ != (term_t)0);
@@ -697,7 +697,7 @@ PlTermv::PlTermv(const PlTerm& m0, const PlTerm& m1)
 }
 
 _SWI_CPP2_CPP_inline
-PlTermv::PlTermv(const PlTerm& m0, const PlTerm& m1, const PlTerm& m2)
+PlTermv::PlTermv(PlTerm m0, PlTerm m1, PlTerm m2)
   : size_(3),
     a0_(Plx_new_term_refs(3))
 { PlEx<bool>(a0_ != (term_t)0);
@@ -707,7 +707,7 @@ PlTermv::PlTermv(const PlTerm& m0, const PlTerm& m1, const PlTerm& m2)
 }
 
 _SWI_CPP2_CPP_inline
-PlTermv::PlTermv(const PlTerm& m0, const PlTerm& m1, const PlTerm& m2, const PlTerm& m3)
+PlTermv::PlTermv(PlTerm m0, PlTerm m1, PlTerm m2, PlTerm m3)
   : size_(4),
     a0_(Plx_new_term_refs(4))
 { PlEx<bool>(a0_ != (term_t)0);
@@ -718,8 +718,7 @@ PlTermv::PlTermv(const PlTerm& m0, const PlTerm& m1, const PlTerm& m2, const PlT
 }
 
 _SWI_CPP2_CPP_inline
-PlTermv::PlTermv(const PlTerm& m0, const PlTerm& m1, const PlTerm& m2,
-                 const PlTerm& m3, const PlTerm& m4)
+PlTermv::PlTermv(PlTerm m0, PlTerm m1, PlTerm m2, PlTerm m3, PlTerm m4)
   : size_(5),
     a0_(Plx_new_term_refs(5))
 { PlEx<bool>(a0_ != (term_t)0);

--- a/SWI-cpp2.h
+++ b/SWI-cpp2.h
@@ -503,6 +503,10 @@ public:
   bool is_atom()     const { return Plx_is_atom(unwrap()); }
   bool is_integer()  const { return Plx_is_integer(unwrap()); }
   bool is_string()   const { return Plx_is_string(unwrap()); }
+  bool is_atom_or_string() const
+  { int t = type();
+    return t == PL_ATOM || t == PL_STRING;
+  }
   bool is_float()    const { return Plx_is_float(unwrap()); }
   bool is_rational() const { return Plx_is_rational(unwrap()); }
   bool is_compound() const { return Plx_is_compound(unwrap()); }
@@ -515,6 +519,27 @@ public:
   bool is_acyclic()  const { return Plx_is_acyclic(unwrap()); }
   bool is_functor(PlFunctor f) const { return Plx_is_functor(unwrap(), f.unwrap()); }
   bool is_blob(PL_blob_t **type) const { return Plx_is_blob(unwrap(), type); }
+
+  void must_be_attvar()   const;
+  void must_be_variable() const;
+  void must_be_ground()   const;
+  void must_be_atom()     const;
+  void must_be_integer()  const;
+  void must_be_string()   const;
+  void must_be_atom_or_string() const;
+  void must_be_float()    const;
+  void must_be_rational() const;
+  void must_be_compound() const;
+  void must_be_callable() const;
+  void must_be_list()     const;
+  void must_be_dict()     const;
+  void must_be_pair()     const;
+  void must_be_atomic()   const;
+  void must_be_number()   const;
+  void must_be_acyclic()  const;
+  // TODO: if needed
+  // void must_be_functor(PlFunctor f) const;
+  // void must_be_blob(PL_blob_t **type) const;
 
   void put_variable()                                      { Plx_put_variable(unwrap()); }
   void put_atom(PlAtom a)                                  { Plx_put_atom(unwrap(), a.unwrap()); }

--- a/SWI-cpp2.h
+++ b/SWI-cpp2.h
@@ -184,13 +184,13 @@ public:
   WrappedC<C_t>(            const WrappedC<C_t>&) = default;
   WrappedC<C_t>& operator =(const WrappedC<C_t>&) = default;
   // This simple wrapper class doesn't need a move constructor or
-  // move operator=.
+  // move operator =.
 
   ~WrappedC<C_t>() { }
 
   operator bool() const = delete; // Use not_null(), is_null() instead
-  bool operator ==(const WrappedC<C_t>& o) const { return C_ == o.C_; }
-  bool operator !=(const WrappedC<C_t>& o) const { return C_ != o.C_; }
+  bool operator ==(WrappedC<C_t> o) const { return C_ == o.C_; }
+  bool operator !=(WrappedC<C_t> o) const { return C_ != o.C_; }
 
   // reset() is common with "smart pointers"; wrapped atom_t, term_t,
   // etc. aren't "smart" in the same sense, but the objects they refer
@@ -308,18 +308,20 @@ public:
 
   [[nodiscard]] int write(IOSTREAM *s, int flags) const;
 
-  // TODO: operator == should be `override`
-  bool operator ==(const PlAtom& to) const /*override*/ { return unwrap() == to.unwrap(); }
-  bool operator !=(const PlAtom& to) const /*override*/ { return unwrap() != to.unwrap(); }
-  [[deprecated("use as_string() or ==PlAtom")]] bool operator ==(const char *s) const { return eq(s); }
-  bool operator ==(const wchar_t *s) const { return eq(s); }
-  [[deprecated("use as_string() or ==PlAtom")]] bool operator ==(const std::string& s) const { return eq(s); }
-  bool operator ==(const std::wstring& s) const { return eq(s); }
-  [[deprecated("use PlAtom instead of atomt_t")]] bool operator ==(atom_t to) const { return unwrap() == to; }
+  // TODO: operator ==(PlAtom) is defined by WrappedC<C_t> but
+  //       the following is needed to avoid amiguous overload:
+  bool operator ==(PlAtom to) const { return unwrap() == to.unwrap(); }
+  bool operator !=(PlAtom to) const { return unwrap() != to.unwrap(); }
 
-  [[deprecated("use as_string() or !=PlAtom")]] bool operator !=(const char *s) const { return !eq(s); }
-  bool operator !=(const wchar_t *s) const { return !eq(s); }
-  [[deprecated("use PlAtom instead of atom_t")]] bool operator !=(atom_t to) const { return unwrap() != to; }
+  [[deprecated("use as_string() or ==PlAtom")]]  bool operator ==(const char *s)         const { return eq(s); }
+  [[deprecated("use as_string() or ==PlAtom")]]  bool operator ==(const wchar_t *s)      const { return eq(s); }
+  [[deprecated("use as_string() or ==PlAtom")]]  bool operator ==(const std::string& s)  const { return eq(s); }
+  [[deprecated("use as_string() or ==PlAtom")]]  bool operator ==(const std::wstring& s) const { return eq(s); }
+  [[deprecated("use PlAtom instead of atom_t")]] bool operator ==(atom_t to)             const { return unwrap() == to; }
+
+  [[deprecated("use as_string() or !=PlAtom")]]  bool operator !=(const char *s)         const { return !eq(s); }
+  [[deprecated("use as_string() or !=PlAtom")]]  bool operator !=(const wchar_t *s)      const { return !eq(s); }
+  [[deprecated("use PlAtom instead of atom_t")]] bool operator !=(atom_t to)             const { return unwrap() != to; }
 
   // TODO: when C++17 becomes standard, rename register_ref() to register().
 
@@ -426,7 +428,7 @@ protected:
   { }
 
 public:
-  explicit PlTerm(const PlAtom& a)
+  explicit PlTerm(PlAtom a)
     : WrappedC<term_t>(Plx_new_term_ref())
   { Plx_put_atom(unwrap(), a.unwrap());
   }
@@ -445,7 +447,7 @@ public:
 
   // TODO: PlTerm& operator =(const PlTerm&) = delete; // TODO: when the deprecated items below are removed
 
-  [[nodiscard]] bool get_atom(PlAtom *A) const { return Plx_get_atom(unwrap(), PlUnwrapAsPtr(A)); }
+  [[nodiscard]] bool get_atom(PlAtom *a) const { return Plx_get_atom(unwrap(), PlUnwrapAsPtr(a)); }
   [[nodiscard]] bool get_bool(int *value) const { return Plx_get_bool(unwrap(), value); }
   [[nodiscard]] bool get_chars(char **s, unsigned int flags) const { return Plx_get_chars(unwrap(), s, flags); }
   [[nodiscard]] bool get_list_chars(char **s, unsigned int flags) const { return Plx_get_list_chars(unwrap(), s, flags); }
@@ -511,7 +513,7 @@ public:
   bool is_atomic()   const { return Plx_is_atomic(unwrap()); }
   bool is_number()   const { return Plx_is_number(unwrap()); }
   bool is_acyclic()  const { return Plx_is_acyclic(unwrap()); }
-  bool is_functor(const PlFunctor& f) const { return Plx_is_functor(unwrap(), f.unwrap()); }
+  bool is_functor(PlFunctor f) const { return Plx_is_functor(unwrap(), f.unwrap()); }
   bool is_blob(PL_blob_t **type) const { return Plx_is_blob(unwrap(), type); }
 
   void put_variable()                                      { Plx_put_variable(unwrap()); }
@@ -613,20 +615,20 @@ public:
   // with implicit or explicit cast from, e.g. PlAtom to PlTerm
 
 						/* UNIFY */
-  [[deprecated("use unify_*()")]] [[nodiscard]] bool operator =(const PlTerm& t2)   const { return unify_term(t2); }
-  [[deprecated("use unify_*()")]] [[nodiscard]] bool operator =(const PlAtom& a)    const { return unify_atom(a); }
-  [[deprecated("use unify_*()")]] [[nodiscard]] bool operator =(const char *v)      const { return unify_atom(v); }
-  [[deprecated("use unify_*()")]] [[nodiscard]] bool operator =(const wchar_t *v)   const { return unify_atom(v); }
-  [[deprecated("use unify_*()")]] [[nodiscard]] bool operator =(intptr_t v)         const { return unify_integer(v); }
-  [[deprecated("use unify_*()")]] [[nodiscard]] bool operator =(double v)           const { return unify_float(v); }
-  [[deprecated("use unify_*()")]] [[nodiscard]] bool operator =(const PlFunctor& f) const { return unify_functor(f); }
+  [[deprecated("use unify_*()")]] [[nodiscard]] bool operator =(PlTerm t2)        const { return unify_term(t2); }
+  [[deprecated("use unify_*()")]] [[nodiscard]] bool operator =(PlAtom a)         const { return unify_atom(a); }
+  [[deprecated("use unify_*()")]] [[nodiscard]] bool operator =(const char *v)    const { return unify_atom(v); }
+  [[deprecated("use unify_*()")]] [[nodiscard]] bool operator =(const wchar_t *v) const { return unify_atom(v); }
+  [[deprecated("use unify_*()")]] [[nodiscard]] bool operator =(intptr_t v)       const { return unify_integer(v); }
+  [[deprecated("use unify_*()")]] [[nodiscard]] bool operator =(double v)         const { return unify_float(v); }
+  [[deprecated("use unify_*()")]] [[nodiscard]] bool operator =(PlFunctor f)      const { return unify_functor(f); }
 
   // All the unify_*() methods check for an exception (and throw), so
   // the return code is whether the unification succeeded or not.
   // TODO: replace PL_unify_*() with PL_unify_string() and flags, where appropriate
   // TODO: encodings for char*, std::string
-  [[nodiscard]] bool unify_term(const PlTerm& t2)        const { return Plx_unify(unwrap(), t2.unwrap()); }
-  [[nodiscard]] bool unify_atom(const PlAtom& a)         const { return Plx_unify_atom(unwrap(), a.unwrap()); }
+  [[nodiscard]] bool unify_term(PlTerm t2)               const { return Plx_unify(unwrap(), t2.unwrap()); }
+  [[nodiscard]] bool unify_atom(PlAtom a)                const { return Plx_unify_atom(unwrap(), a.unwrap()); }
   [[nodiscard]] bool unify_chars(int flags, size_t len, const char *s) const { return Plx_unify_chars(unwrap(), flags, len, s); }
   [[nodiscard]] bool unify_chars(int flags, const std::string& s) const { return Plx_unify_chars(unwrap(), flags, s.size(), s.data()); }
   [[nodiscard]] bool unify_atom(const char*           v) const { return Plx_unify_atom_chars(unwrap(), v); }
@@ -650,8 +652,8 @@ public:
   [[nodiscard]] bool unify_integer(unsigned short     v) const { return Plx_unify_uint64(unwrap(), v); }
   [[nodiscard]] bool unify_float(double               v) const { return Plx_unify_float(unwrap(), v); }
   [[nodiscard]] bool unify_string(const std::string&  v) const { return Plx_unify_string_nchars(unwrap(), v.size(), v.data()); }
-  [[nodiscard]] bool unify_string(const std::wstring& v) const { return Plx_unify_wchars(unwrap(), PL_STRING, v.size(), v.data()); }
-  [[nodiscard]] bool unify_functor(const PlFunctor&   f) const { return Plx_unify_functor(unwrap(), f.unwrap()); }
+  [[nodiscard]] bool unify_wstring(const std::wstring& v) const { return Plx_unify_wchars(unwrap(), PL_STRING, v.size(), v.data()); }
+  [[nodiscard]] bool unify_functor(PlFunctor          f) const { return Plx_unify_functor(unwrap(), f.unwrap()); }
   [[nodiscard]] bool unify_pointer(void *ptr)            const { return Plx_unify_pointer(unwrap(), ptr); } // TODO: replace with C++ interface to blobs
   [[nodiscard]] bool unify_nil()                         const { return Plx_unify_nil(unwrap()); }
   [[nodiscard]] bool unify_list(PlTerm h, PlTerm t)      const { return Plx_unify_list(unwrap(), h.unwrap(), t.unwrap()); }
@@ -666,35 +668,34 @@ public:
   // TODO: PL_unify_mpz(), PL_unify_mpq()
 
 					/* Comparison standard order terms */
-  [[nodiscard]] int compare(const PlTerm& t2) const { return Plx_compare(unwrap(), t2.unwrap()); }
-  // TODO: operator == should be `override`
-  bool operator ==(const PlTerm& t2) const /*override*/ { return compare(t2) == 0; }
-  bool operator !=(const PlTerm& t2) const /*override*/ { return compare(t2) != 0; }
-  bool operator < (const PlTerm& t2) const { return compare(t2) <  0; }
-  bool operator > (const PlTerm& t2) const { return compare(t2) >  0; }
-  bool operator <=(const PlTerm& t2) const { return compare(t2) <= 0; }
-  bool operator >=(const PlTerm& t2) const { return compare(t2) >= 0; }
+  [[nodiscard]] int compare(PlTerm t2) const { return Plx_compare(unwrap(), t2.unwrap()); }
+  bool operator ==(PlTerm t2) const { return compare(t2) == 0; }
+  bool operator !=(PlTerm t2) const { return compare(t2) != 0; }
+  bool operator < (PlTerm t2) const { return compare(t2) <  0; }
+  bool operator > (PlTerm t2) const { return compare(t2) >  0; }
+  bool operator <=(PlTerm t2) const { return compare(t2) <= 0; }
+  bool operator >=(PlTerm t2) const { return compare(t2) >= 0; }
 					/* comparison (long) */
   /* TODO: uint64_t; but that requires adding a lot of overloaded methods */
-  bool operator ==(int64_t v) const;
-  bool operator !=(int64_t v) const;
-  bool operator < (int64_t v) const;
-  bool operator > (int64_t v) const;
-  bool operator <=(int64_t v) const;
-  bool operator >=(int64_t v) const;
+  [[deprecated("use as_int64_t()")]] bool operator ==(int64_t v) const;
+  [[deprecated("use as_int64_t()")]] bool operator !=(int64_t v) const;
+  [[deprecated("use as_int64_t()")]] bool operator < (int64_t v) const;
+  [[deprecated("use as_int64_t()")]] bool operator > (int64_t v) const;
+  [[deprecated("use as_int64_t()")]] bool operator <=(int64_t v) const;
+  [[deprecated("use as_int64_t()")]] bool operator >=(int64_t v) const;
 
 					/* comparison (atom, string) */
-  [[deprecated("use as_string()")]] bool operator ==(const char *s) const { return eq(s); }
-  [[deprecated("use as_string()")]] bool operator ==(const wchar_t *s) const { return eq(s); }
-  [[deprecated("use as_string()")]] bool operator ==(const std::string& s) const { return eq(s); }
-  bool operator ==(const std::wstring& s) const { return eq(s); }
-  bool operator ==(const PlAtom& a) const { return eq(a); }
+  [[deprecated("use as_string()")]]  bool operator ==(const char *s) const { return eq(s); }
+  [[deprecated("use as_string()")]]  bool operator ==(const wchar_t *s) const { return eq(s); }
+  [[deprecated("use as_wstring()")]] bool operator ==(const std::string& s) const { return eq(s); }
+  [[deprecated("use as_wstring()")]] bool operator ==(const std::wstring& s) const { return eq(s); }
+  [[deprecated("use as_atom()")]]    bool operator ==(PlAtom a) const { return eq(a); }
 
-  [[deprecated("use as_string()")]] bool operator !=(const char *s)         const { return !eq(s); }
-  bool operator !=(const wchar_t *s)      const { return !(eq(s)); }
-  [[deprecated("use as_string()")]] bool operator !=(const std::string& s)  const { return !eq(s); }
-  bool operator !=(const std::wstring& s) const { return !eq(s); }
-  bool operator !=(const PlAtom& a)       const { return !eq(a); }
+  [[deprecated("use as_string()")]]  bool operator !=(const char *s)         const { return !eq(s); }
+  [[deprecated("use as_wstring()")]] bool operator !=(const wchar_t *s)      const { return !(eq(s)); }
+  [[deprecated("use as_string()")]]  bool operator !=(const std::string& s)  const { return !eq(s); }
+  [[deprecated("use as_wstring()")]] bool operator !=(const std::wstring& s) const { return !eq(s); }
+  [[deprecated("use as_atom()")]]    bool operator !=(PlAtom a)              const { return !eq(a); }
 
   // E.g.: t.write(Serror, 1200, PL_WRT_QUOTED);
   [[nodiscard]] int write(IOSTREAM *s, int precedence, int flags) const
@@ -709,7 +710,7 @@ private:
   bool eq(const wchar_t *s) const;
   bool eq(const std::string& s) const;
   bool eq(const std::wstring& s) const;
-  bool eq(const PlAtom& a) const;
+  bool eq(PlAtom a) const;
 };
 
 
@@ -719,7 +720,7 @@ public:
   // TODO: Add encoding for char*, std::string.
   //       For now, these are safe only with ASCII (PlEncoding::Latin1):
   explicit PlTerm_atom(atom_t a)                 { Plx_put_atom(unwrap(), a); }
-  explicit PlTerm_atom(const PlAtom& a)          { Plx_put_atom(unwrap(), a.unwrap()); }
+  explicit PlTerm_atom(PlAtom a)                 { Plx_put_atom(unwrap(), a.unwrap()); }
   explicit PlTerm_atom(const char *text)         { Plx_put_atom_chars(unwrap(), text); } // TODO: add encoding
   explicit PlTerm_atom(const wchar_t *text)      { PlEx<bool>(Plx_unify_wchars(unwrap(), PL_ATOM, static_cast<size_t>(-1), text)); }
   explicit PlTerm_atom(const std::string& text)  { Plx_put_atom_nchars(unwrap(), text.size(), text.data()); } // TODO: add encoding
@@ -822,7 +823,7 @@ public:
   { if ( size_  )
       PlEx<bool>(a0_ != (term_t)0);
   }
-  explicit PlTermv(size_t n, const PlTerm& t0)
+  explicit PlTermv(size_t n, PlTerm t0)
     : size_(n),
       a0_(t0.unwrap())
   { // Assume that t0 is valid - it can be if 0 if PREDICATE_NONDET is
@@ -846,12 +847,12 @@ public:
   // TODO: PlTermv copy_term_ref() const
 
 					/* create from args */
-  explicit PlTermv(const PlAtom& a);
-  explicit PlTermv(const PlTerm& m0);
-  explicit PlTermv(const PlTerm& m0, const PlTerm& m1);
-  explicit PlTermv(const PlTerm& m0, const PlTerm& m1, const PlTerm& m2);
-  explicit PlTermv(const PlTerm& m0, const PlTerm& m1, const PlTerm& m2, const PlTerm& m3);
-  explicit PlTermv(const PlTerm& m0, const PlTerm& m1, const PlTerm& m2, const PlTerm& m3, const PlTerm& m4);
+  explicit PlTermv(PlAtom a);
+  explicit PlTermv(PlTerm m0);
+  explicit PlTermv(PlTerm m0, PlTerm m1);
+  explicit PlTermv(PlTerm m0, PlTerm m1, PlTerm m2);
+  explicit PlTermv(PlTerm m0, PlTerm m1, PlTerm m2, PlTerm m3);
+  explicit PlTermv(PlTerm m0, PlTerm m1, PlTerm m2, PlTerm m3, PlTerm m4);
 
   PlTerm operator [](size_t n) const;
 };
@@ -918,8 +919,10 @@ public:
   PlRecord(const PlRecord& r)
     : WrappedC<record_t>(r)
   { }
+
   PlRecord& operator =(const PlRecord& r)
-  { reset(r);
+  { if ( this != &r )
+      reset(r);
     return *this;
   }
 
@@ -948,14 +951,14 @@ public:
 class PlRecordDeleter
 {
 public:
-  void operator()(PlRecord *r) const
+  void operator ()(PlRecord *r) const
   { r->erase();
     delete r;
   }
 };
 
 
-class PlRecordExternalCopy // TODO: public WrappedC<std::string>
+class PlRecordExternalCopy
 {
 private:
   std::string C_ = "";
@@ -1016,10 +1019,10 @@ private:
 class PlException : public PlExceptionBase
 {
 public:
-  explicit PlException(const PlTerm& t)
+  explicit PlException(PlTerm t)
     : term_rec_(t) { }
 
-  explicit PlException(const PlAtom& a)
+  explicit PlException(PlAtom a)
     : term_rec_(PlTerm_atom(a)) { }
 
   PlException(const PlException& e)
@@ -1084,21 +1087,21 @@ protected:
 
 PlException PlGeneralError(PlTerm inside);
 
-PlException PlTypeError(const std::string& expected, const PlTerm& actual);
+PlException PlTypeError(const std::string& expected, PlTerm actual);
 
-PlException PlDomainError(const std::string& expected, const PlTerm& actual);
+PlException PlDomainError(const std::string& expected, PlTerm actual);
 
-PlException PlDomainError(const PlTerm& expected, const PlTerm& actual);
+PlException PlDomainError(PlTerm expected, PlTerm actual);
 
-PlException PlInstantiationError(const PlTerm& t);
+PlException PlInstantiationError(PlTerm t);
 
-PlException PlUninstantiationError(const PlTerm& t);
+PlException PlUninstantiationError(PlTerm t);
 
 PlException PlRepresentationError(const std::string& resource);
 
 PlException PlExistenceError(const std::string& type, PlTerm actual);
 
-PlException PlPermissionError(const std::string& op, const std::string& type, const PlTerm& obj);
+PlException PlPermissionError(const std::string& op, const std::string& type, PlTerm obj);
 
 PlException PlResourceError(const std::string& resource);
 
@@ -1135,7 +1138,7 @@ PlCheckFail(bool rc)
 class PlTerm_tail : public PlTerm
 {
 public:
-  explicit PlTerm_tail(const PlTerm& l);
+  explicit PlTerm_tail(PlTerm l);
 
 					/* building */
   [[nodiscard]] bool append(PlTerm e);
@@ -1357,6 +1360,7 @@ int PlCall(const std::string& module, const std::string& predicate, const PlTerm
 int PlCall(const std::string& goal, int flags = PL_Q_PASS_EXCEPTION);
 int PlCall(const std::wstring& goal, int flags = PL_Q_PASS_EXCEPTION);
 int PlCall(PlTerm goal, int flags = PL_Q_PASS_EXCEPTION);
+
 		 /*******************************
 		 *	      ENGINE		*
 		 *******************************/

--- a/test_cpp.cpp
+++ b/test_cpp.cpp
@@ -591,11 +591,19 @@ PREDICATE(hostname2, 1)
 }
 
 PREDICATE(eq_int64, 2)
-{ return A1 == A2.as_int64_t();
+{
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  return A1 == A2.as_int64_t();
+  #pragma GCC diagnostic pop
 }
 
 PREDICATE(lt_int64, 2)
-{ return A1 < A2.as_int64_t();
+{
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  return A1 < A2.as_int64_t();
+  #pragma GCC diagnostic pop
 }
 
 PREDICATE(get_atom_ex, 2)

--- a/test_cpp.cpp
+++ b/test_cpp.cpp
@@ -1034,23 +1034,24 @@ static const std::map<const std::string, std::pair<PlRecord, PlRecord>> name_to_
   };
 
 PREDICATE(name_to_terms, 3)
-{ PlTerm key(A1), term1(A2), term2(A3);
-  const auto it = name_to_term.find(key.as_string());
+{ A1.must_be_atom_or_string();
+  const auto it = name_to_term.find(A1.as_string());
   return it != name_to_term.cend() &&
-    PlRewindOnFail([term1,term2,it]() -> bool
-                   { return term1.unify_term(it->second.first.term()) &&
-                            term2.unify_term(it->second.second.term()); });
+    PlRewindOnFail([t1=A2,t2=A3,&it]()
+                   { return t1.unify_term(it->second.first.term()) &&
+                            t2.unify_term(it->second.second.term()); });
 }
 
 PREDICATE(name_to_terms2, 3)
-{ PlTerm key(A1), term1(A2), term2(A3);
+{ PlTerm key(A1), t1(A2), t2(A3);
+  key.must_be_atom_or_string();
   const auto it = name_to_term.find(key.as_string());
   if ( it == name_to_term.cend() )
     return false;
-  if ( !term1.unify_term(it->second.first.term()) )
+  if ( !t1.unify_term(it->second.first.term()) )
     return false;
   PlFrame fr;
-  if ( !term2.unify_term(it->second.second.term()) )
+  if ( !t2.unify_term(it->second.second.term()) )
   { fr.discard();
     return false;
   }

--- a/test_cpp.pl
+++ b/test_cpp.pl
@@ -624,6 +624,8 @@ test(name_to_terms, fail) :-
     name_to_terms("foo", _, _).
 test(name_to_terms, fail) :-
     name_to_terms("two", _, "deux").
+test(name_to_terms, error(type_error('atom or string',A))) :-
+     name_to_terms(A, 1, 2).
 
 test(name_to_terms2, [T1,T2] = [1,"eins"]) :-
     name_to_terms2("one", T1, T2).


### PR DESCRIPTION
Apparently some compilers can optimise "const PlTerm&" to "PlTerm" in a function call, but it's not clear that all can.
There's one situation where this change introduced an ambiguity, at least with gcc 12.2. I've added a "TODO" comment about that.