### PR TITLE
tell and Stell return long

### DIFF
--- a/SWI-cpp2.cpp
+++ b/SWI-cpp2.cpp
@@ -983,7 +983,7 @@ _SWI_CPP2_CPP_check_rc(int, setlocale(struct PL_locale *new_loc, struct PL_local
 _SWI_CPP2_CPP_check_rc(int, flush(), Sflush(s_))
 _SWI_CPP2_CPP_check_rc(int64_t, size(), Ssize(s_))
 _SWI_CPP2_CPP_check_rc(int, seek(long pos, int whence), Sseek(s_, pos, whence))
-_SWI_CPP2_CPP_check_rc(int, tell(), Stell(s_))
+_SWI_CPP2_CPP_check_rc(long, tell(), Stell(s_))
 _SWI_CPP2_CPP_check_rc(int, close(), Sclose(s_))
 _SWI_CPP2_CPP_check_rc(int, gcclose(int flags), Sgcclose(s_, flags))
 _SWI_CPP2_CPP_check_rc(ssize_t, read_pending(char *buf, size_t limit, int flags), Sread_pending(s_, buf, limit, flags))


### PR DESCRIPTION
Avoids a warning on implicit conversion loss from 'long' to 'int' [-Wshorten-64-to-32]