### PR TITLE
Omit template-id in constructors for C++20

### DIFF
--- a/SWI-cpp2.h
+++ b/SWI-cpp2.h
@@ -179,15 +179,15 @@ public:
 
   friend C_t *PlUnwrapAsPtr(WrappedC<C_t>* obj) { return obj ? obj->unwrap_as_ptr() : nullptr; }
 
-  explicit WrappedC<C_t>(C_t v)
+  explicit WrappedC(C_t v)
     : C_(v) { }
 
-  WrappedC<C_t>(            const WrappedC<C_t>&) = default;
-  WrappedC<C_t>& operator =(const WrappedC<C_t>&) = default;
+  WrappedC(            const WrappedC<C_t>&) = default;
+  WrappedC& operator =(const WrappedC<C_t>&) = default;
   // This simple wrapper class doesn't need a move constructor or
   // move operator =.
 
-  ~WrappedC<C_t>() { }
+  ~WrappedC() { }
 
   operator bool() const = delete; // Use not_null(), is_null() instead
   bool operator ==(WrappedC<C_t> o) const { return C_ == o.C_; }
@@ -1667,12 +1667,12 @@ class PlForeignContextPtr
 {
 public:
   [[deprecated("Use PlControl::context_unique_ptr")]]
-  explicit PlForeignContextPtr<ContextType>(PlControl handle)
+  explicit PlForeignContextPtr(PlControl handle)
   { ptr_.reset(static_cast<ContextType *>(handle.foreign_context_address()));
   }
 
-  PlForeignContextPtr<ContextType>(const PlForeignContextPtr<ContextType>&) = delete;
-  PlForeignContextPtr<ContextType>(PlForeignContextPtr<ContextType>&&) = delete;
+  PlForeignContextPtr(const PlForeignContextPtr<ContextType>&) = delete;
+  PlForeignContextPtr(PlForeignContextPtr<ContextType>&&) = delete;
   PlForeignContextPtr<ContextType>& operator =(const PlForeignContextPtr<ContextType>&) = delete;
   PlForeignContextPtr<ContextType>& operator =(PlForeignContextPtr<ContextType>&&) = delete;
 


### PR DESCRIPTION
In C++20, a simple-template-id is no longer allowed as the declarator-id for constructors and destructors.  See https://cplusplus.github.io/CWG/issues/2237.html for the rationale.  Recent versions of gcc warn about this:
```
In file included from /builddir/build/BUILD/swipl-9.2.3/packages/cpp/test_cpp.cpp:63:
/builddir/build/BUILD/swipl-9.2.3/packages/cpp/SWI-cpp2.h:182:26: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
  182 |   explicit WrappedC<C_t>(C_t v)
      |                          ^~~
/builddir/build/BUILD/swipl-9.2.3/packages/cpp/SWI-cpp2.h:182:26: note: remove the ‘< >’
/builddir/build/BUILD/swipl-9.2.3/packages/cpp/SWI-cpp2.h:185:16: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
  185 |   WrappedC<C_t>(            const WrappedC<C_t>&) = default;
      |                ^
/builddir/build/BUILD/swipl-9.2.3/packages/cpp/SWI-cpp2.h:185:16: note: remove the ‘< >’
/builddir/build/BUILD/swipl-9.2.3/packages/cpp/SWI-cpp2.h:190:3: warning: template-id not allowed for destructor in C++20 [-Wtemplate-id-cdtor]
  190 |   ~WrappedC<C_t>() { }
      |   ^
/builddir/build/BUILD/swipl-9.2.3/packages/cpp/SWI-cpp2.h:190:3: note: remove the ‘< >’
/builddir/build/BUILD/swipl-9.2.3/packages/cpp/SWI-cpp2.h:1670:45: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
 1670 |   explicit PlForeignContextPtr<ContextType>(PlControl handle)
      |                                             ^~~~~~~~~
/builddir/build/BUILD/swipl-9.2.3/packages/cpp/SWI-cpp2.h:1670:45: note: remove the ‘< >’
/builddir/build/BUILD/swipl-9.2.3/packages/cpp/SWI-cpp2.h:1674:35: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
 1674 |   PlForeignContextPtr<ContextType>(const PlForeignContextPtr<ContextType>&) = delete;
      |                                   ^
/builddir/build/BUILD/swipl-9.2.3/packages/cpp/SWI-cpp2.h:1674:35: note: remove the ‘< >’
/builddir/build/BUILD/swipl-9.2.3/packages/cpp/SWI-cpp2.h:1675:36: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
 1675 |   PlForeignContextPtr<ContextType>(PlForeignContextPtr<ContextType>&&) = delete;
      |                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/builddir/build/BUILD/swipl-9.2.3/packages/cpp/SWI-cpp2.h:1675:36: note: remove the ‘< >’
```
