### PR TITLE
Improve deprecated message, add pragma to suppress messsage in test_cpp.cpp

### DIFF
--- a/SWI-cpp2.h
+++ b/SWI-cpp2.h
@@ -316,15 +316,15 @@ public:
   bool operator ==(PlAtom to) const { return unwrap() == to.unwrap(); }
   bool operator !=(PlAtom to) const { return unwrap() != to.unwrap(); }
 
-  [[deprecated("use as_string() or ==PlAtom")]]  bool operator ==(const char *s)         const { return eq(s); }
-  [[deprecated("use as_string() or ==PlAtom")]]  bool operator ==(const wchar_t *s)      const { return eq(s); }
-  [[deprecated("use as_string() or ==PlAtom")]]  bool operator ==(const std::string& s)  const { return eq(s); }
-  [[deprecated("use as_string() or ==PlAtom")]]  bool operator ==(const std::wstring& s) const { return eq(s); }
-  [[deprecated("use PlAtom instead of atom_t")]] bool operator ==(atom_t to)             const { return unwrap() == to; }
+  [[deprecated("use as_string() and std::string::operator==() or ==PlAtom")]]   bool operator ==(const char *s)         const { return eq(s); }
+  [[deprecated("use as_string() and std::string::operator==() or ==PlAtom")]]   bool operator ==(const wchar_t *s)      const { return eq(s); }
+  [[deprecated("use as_string() and std::string::operator==() or ==PlAtom")]]   bool operator ==(const std::string& s)  const { return eq(s); }
+  [[deprecated("use as_swtring() and std::wstring::operator==() or ==PlAtom")]] bool operator ==(const std::wstring& s) const { return eq(s); }
+  [[deprecated("use PlAtom instead of atom_t")]]                                bool operator ==(atom_t to)             const { return unwrap() == to; }
 
-  [[deprecated("use as_string() or !=PlAtom")]]  bool operator !=(const char *s)         const { return !eq(s); }
-  [[deprecated("use as_string() or !=PlAtom")]]  bool operator !=(const wchar_t *s)      const { return !eq(s); }
-  [[deprecated("use PlAtom instead of atom_t")]] bool operator !=(atom_t to)             const { return unwrap() != to; }
+  [[deprecated("use as_string() and std::string::operator!=() or !=PlAtom")]]   bool operator !=(const char *s)         const { return !eq(s); }
+  [[deprecated("use as_string() and std::string::operator!=() or !=PlAtom")]]   bool operator !=(const wchar_t *s)      const { return !eq(s); }
+  [[deprecated("use PlAtom instead of atom_t")]]                                bool operator !=(atom_t to)             const { return unwrap() != to; }
 
   // TODO: when C++17 becomes standard, rename register_ref() to register().
 
@@ -710,25 +710,25 @@ public:
   bool operator <=(PlTerm t2) const { return compare(t2) <= 0; }
   bool operator >=(PlTerm t2) const { return compare(t2) >= 0; }
 					/* comparison (long) */
-  [[deprecated("use as_int64_t()")]] bool operator ==(int64_t v) const;
-  [[deprecated("use as_int64_t()")]] bool operator !=(int64_t v) const;
-  [[deprecated("use as_int64_t()")]] bool operator < (int64_t v) const;
-  [[deprecated("use as_int64_t()")]] bool operator > (int64_t v) const;
-  [[deprecated("use as_int64_t()")]] bool operator <=(int64_t v) const;
-  [[deprecated("use as_int64_t()")]] bool operator >=(int64_t v) const;
+  [[deprecated("use as_int64_t() and int64_t::operator==()")]] bool operator ==(int64_t v) const;
+  [[deprecated("use as_int64_t() and int64_t::operator!=()")]] bool operator !=(int64_t v) const;
+  [[deprecated("use as_int64_t() and int64_t::operator<()")]]  bool operator < (int64_t v) const;
+  [[deprecated("use as_int64_t() and int64_t::operator>()")]]  bool operator > (int64_t v) const;
+  [[deprecated("use as_int64_t() and int64_t::operator<=()")]] bool operator <=(int64_t v) const;
+  [[deprecated("use as_int64_t() and int64_t::operator>=()")]] bool operator >=(int64_t v) const;
 
 					/* comparison (atom, string) */
-  [[deprecated("use as_string()")]]  bool operator ==(const char *s)         const { return eq(s); }
-  [[deprecated("use as_string()")]]  bool operator ==(const wchar_t *s)      const { return eq(s); }
-  [[deprecated("use as_wstring()")]] bool operator ==(const std::string& s)  const { return eq(s); }
-  [[deprecated("use as_wstring()")]] bool operator ==(const std::wstring& s) const { return eq(s); }
-  [[deprecated("use as_atom()")]]    bool operator ==(PlAtom a)              const { return eq(a); }
+  [[deprecated("use as_string() and std::string::operator==()")]]    bool operator ==(const char *s)         const { return eq(s); }
+  [[deprecated("use as_string() and std::string::operator==()")]]    bool operator ==(const wchar_t *s)      const { return eq(s); }
+  [[deprecated("use as_wstring() and std::string::operator==()")]]   bool operator ==(const std::string& s)  const { return eq(s); }
+  [[deprecated("use as_wstring() and std::wstring::operator==()")]]  bool operator ==(const std::wstring& s) const { return eq(s); }
+  [[deprecated("use as_atom()")]]                                    bool operator ==(PlAtom a)              const { return eq(a); }
 
-  [[deprecated("use as_string()")]]  bool operator !=(const char *s)         const { return !eq(s); }
-  [[deprecated("use as_wstring()")]] bool operator !=(const wchar_t *s)      const { return !eq(s); }
-  [[deprecated("use as_string()")]]  bool operator !=(const std::string& s)  const { return !eq(s); }
-  [[deprecated("use as_wstring()")]] bool operator !=(const std::wstring& s) const { return !eq(s); }
-  [[deprecated("use as_atom()")]]    bool operator !=(PlAtom a)              const { return !eq(a); }
+  [[deprecated("use as_string() and std::string::operator==()")]]    bool operator !=(const char *s)         const { return !eq(s); }
+  [[deprecated("use as_wstring() and std::wstring::operator==()")]]  bool operator !=(const wchar_t *s)      const { return !eq(s); }
+  [[deprecated("use as_string() and std::string::operator==()")]]    bool operator !=(const std::string& s)  const { return !eq(s); }
+  [[deprecated("use as_wstring() and std::wstring::operator==()")]]  bool operator !=(const std::wstring& s) const { return !eq(s); }
+  [[deprecated("use as_atom()")]]                                    bool operator !=(PlAtom a)              const { return !eq(a); }
 
   // E.g.: t.write(Serror, 1200, PL_WRT_QUOTED);
   [[nodiscard]] int write(IOSTREAM *s, int precedence, int flags) const

--- a/test_cpp.cpp
+++ b/test_cpp.cpp
@@ -650,21 +650,29 @@ PREDICATE(hostname2, 1)
   return true;
 }
 
+// The eq_int64/2 and lt_int64/2 predicates test the deprecated PlTerm::operator==()
+
+#ifdef _MSC_VER
+#pragma warning( push )
+#pragma warning (disable:4996)
+#else
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 PREDICATE(eq_int64, 2)
-{
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  return A1 == A2.as_int64_t();
-  #pragma GCC diagnostic pop
+{ return A1 == A2.as_int64_t();
 }
 
 PREDICATE(lt_int64, 2)
-{
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  return A1 < A2.as_int64_t();
-  #pragma GCC diagnostic pop
+{ return A1 < A2.as_int64_t();
 }
+
+#ifdef _MSC_VER
+#pragma warning( pop )
+#else
+#pragma GCC diagnostic pop
+#endif
 
 PREDICATE(get_atom_ex, 2)
 { PlAtom a(PlTerm::null);


### PR DESCRIPTION
We may need other `#pragma` statements for other compilers. I've slightly rewritten the test code to make these easier to add.