### PR TITLE
Suppress a warning (printf, %p, nullptr)

### DIFF
--- a/test_cpp.cpp
+++ b/test_cpp.cpp
@@ -2174,7 +2174,7 @@ PREDICATE(free_blob, 1)
 
 PREDICATE(nil_repr, 1)
 { char buf[100];
-  snprintf(buf, sizeof buf, "%p", nullptr);
+  snprintf(buf, sizeof buf, "%p", (void*) nullptr);
   return A1.unify_string(buf);
 }
 


### PR DESCRIPTION
printf("%p", nullptr) raises a warning on some systems

see here (at around 89%)
https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-clang/rswipl-00install.html