### PR TITLE
FIXED: compiler warnings for print formats

### DIFF
--- a/SWI-cpp2.cpp
+++ b/SWI-cpp2.cpp
@@ -301,7 +301,7 @@ PlAtom::wchars() const
 
 _SWI_CPP2_CPP_inline
 bool PlBlob::write(IOSTREAM *s, int flags) const
-{ if ( Sfprintf(s, "<%s>(%p", blob_t_->name, this) < 0 )
+{ if ( Sfprintf(s, "<%s>(%p", blob_t_->name, static_cast<const void*>(this)) < 0 )
     return false;
   { bool rc = true;
     try
@@ -318,7 +318,7 @@ bool PlBlob::write(IOSTREAM *s, int flags) const
 
 _SWI_CPP2_CPP_inline
 void PlBlob::save(IOSTREAM *fd) const
-{ (void)PL_warning("Cannot save reference to <%s>(%p)", blob_t_->name, this);
+{ (void)PL_warning("Cannot save reference to <%s>(%p)", blob_t_->name, static_cast<const void*>(this));
   throw PlFail();
 }
 

--- a/SWI-cpp2.h
+++ b/SWI-cpp2.h
@@ -2012,7 +2012,7 @@ public:
   { const auto data = cast(PlAtom(a));
     if ( !data )
       // TODO: demangle typeid::name()
-      return Sfprintf(s, "<%s>(%p)", typeid(C_t).name(), data) >= 0;
+      return Sfprintf(s, "<%s>(%p)", typeid(C_t).name(), static_cast<const void*>(data)) >= 0;
     int rc = -1; // Uninitialized variable warning (some compilers)
     try
     { rc = data->write(s, flags);

--- a/test_cpp.cpp
+++ b/test_cpp.cpp
@@ -138,8 +138,8 @@ PREDICATE(hello3, 2)
   // character in it. In addition, a NUL ('\0') in the atom will cause
   // the rest of the atom to not be printed.
 
-  int len = Ssnprintf(buf, sizeof buf,
-		      "Hello3 %Ws\n", atom_a1.as_wstring().c_str());
+  int len = SsnprintfX(buf, sizeof buf,
+		       "Hello3 %Ws\n", atom_a1.as_wstring().c_str());
   if ( len >= 0 )
     // TODO: use len when fixed: https://github.com/SWI-Prolog/swipl-devel/issues/1074
     return A2.unify_chars(PL_STRING|REP_UTF8, strlen(buf), buf);
@@ -1580,7 +1580,7 @@ struct MyBlob : public PlBlob
       connection(std::make_unique<MyConnection>(connection_name)),
       blob_name(connection_name)
   { if ( !connection ) // make_unique should have thrown exception if it can't allocate
-      PL_api_error("MyBlob(%s) connection=%p", blob_name.c_str(), connection.get());
+      PL_api_error("MyBlob(%s) connection=%p", blob_name.c_str(), static_cast<const void*>(connection.get()));
     if ( !connection->open() )
       throw MyBlobError("my_blob_open_error");
     if ( name_contains("FAIL_new") ) // Test error handling
@@ -2203,7 +2203,7 @@ PREDICATE(free_blob, 1)
 
 PREDICATE(nil_repr, 1)
 { char buf[100];
-  snprintf(buf, sizeof buf, "%p", (void*) nullptr);
+  snprintf(buf, sizeof buf, "%p", static_cast<const void*>(nullptr));
   return A1.unify_string(buf);
 }
 


### PR DESCRIPTION
These were caught by building with the flag -DCHECK_FORMAT

I'm working on another PR that adds this option to scripts/configure