### PR TITLE
ASAN: avoid uninitialized buffer in fread

### DIFF
--- a/test_cpp.cpp
+++ b/test_cpp.cpp
@@ -1727,7 +1727,7 @@ struct MyFileBlob : public PlBlob
   { assert(sizeof buffer_[0] == sizeof (char));
     assert(sizeof (char) == 1);
 
-    buffer_.reserve(count);
+    buffer_.resize(count);
     return std::string(buffer_.data(),
                        std::fread(buffer_.data(), sizeof buffer_[0], count, file_));
   }


### PR DESCRIPTION
This silences an ASAN error mentioned in https://github.com/SWI-Prolog/packages-cpp/issues/105. 

1. I don't really see the point, but maybe clang's ASAN does not like to write into "reserved" but not initialized memory areas.
2. Alternatively, and that may be the reason for the ASAN complaint: buf in the outer std::string(buf, size) function is not "officially" initialized.

In any case, it is a minor modification in an example with no measurable impact on speed or so.