### PR TITLE
Make it easier to generate standard form exceptions

### DIFF
--- a/SWI-cpp.h
+++ b/SWI-cpp.h
@@ -310,7 +310,7 @@ class PlException : public PlTerm
 {
 public:
   PlException()
-  { term_t ex = Plx_exception(0);
+  { term_t ex = Plx_exception();
     if ( ex )
       ref = ex;
     else
@@ -583,7 +583,7 @@ public:
       return TRUE;
     }
 
-    if ( (ex = Plx_exception(0)) )
+    if ( (ex = Plx_exception()) )
       throw PlResourceError(ex);
 
     return FALSE;
@@ -881,7 +881,7 @@ __inline int PlTerm::operator =(const PlTerm &t2)	/* term = term */
 { int rc = PL_unify(ref, t2.ref);
   term_t ex;
 
-  if ( !rc && (ex=Plx_exception(0)) )
+  if ( !rc && (ex=Plx_exception()) )
     throw PlResourceError(ex);
   return rc;
 }
@@ -890,7 +890,7 @@ __inline int PlTerm::operator =(const PlAtom &a)	/* term = atom */
 { int rc = PL_unify_atom(ref, a.handle);
   term_t ex;
 
-  if ( !rc && (ex=Plx_exception(0)) )
+  if ( !rc && (ex=Plx_exception()) )
     throw PlResourceError(ex);
   return rc;
 }
@@ -899,7 +899,7 @@ __inline int PlTerm::operator =(const char *v)		/* term = atom */
 { int rc = PL_unify_atom_chars(ref, v);
   term_t ex;
 
-  if ( !rc && (ex=Plx_exception(0)) )
+  if ( !rc && (ex=Plx_exception()) )
     throw PlResourceError(ex);
   return rc;
 }
@@ -908,7 +908,7 @@ __inline int PlTerm::operator =(const wchar_t *v)	/* term = atom */
 { int rc = PL_unify_wchars(ref, PL_ATOM, static_cast<size_t>(-1), v);
   term_t ex;
 
-  if ( !rc && (ex=Plx_exception(0)) )
+  if ( !rc && (ex=Plx_exception()) )
     throw PlResourceError(ex);
   return rc;
 }
@@ -917,7 +917,7 @@ __inline int PlTerm::operator =(long v)
 { int rc = PL_unify_integer(ref, v);
   term_t ex;
 
-  if ( !rc && (ex=Plx_exception(0)) )
+  if ( !rc && (ex=Plx_exception()) )
     throw PlResourceError(ex);
   return rc;
 }
@@ -926,7 +926,7 @@ __inline int PlTerm::operator =(int v)
 { int rc = PL_unify_integer(ref, v);
   term_t ex;
 
-  if ( !rc && (ex=Plx_exception(0)) )
+  if ( !rc && (ex=Plx_exception()) )
     throw PlResourceError(ex);
   return rc;
 }
@@ -935,7 +935,7 @@ __inline int PlTerm::operator =(double v)
 { int rc = PL_unify_float(ref, v);
   term_t ex;
 
-  if ( !rc && (ex=Plx_exception(0)) )
+  if ( !rc && (ex=Plx_exception()) )
     throw PlResourceError(ex);
   return rc;
 }
@@ -944,7 +944,7 @@ __inline int PlTerm::operator =(const PlFunctor &f)
 { int rc = PL_unify_functor(ref, f.functor);
   term_t ex;
 
-  if ( !rc && (ex=Plx_exception(0)) )
+  if ( !rc && (ex=Plx_exception()) )
     throw PlResourceError(ex);
   return rc;
 }
@@ -1227,7 +1227,7 @@ PlQuery::next_solution()
     PL_close_query(qid);
     qid = 0;
 
-    if ( (ex = Plx_exception(0)) )
+    if ( (ex = Plx_exception()) )
       PlException(ex).cppThrow();
   }
   return rval;

--- a/SWI-cpp.h
+++ b/SWI-cpp.h
@@ -310,7 +310,7 @@ class PlException : public PlTerm
 {
 public:
   PlException()
-  { term_t ex = PL_exception(0);
+  { term_t ex = Plx_exception(0);
     if ( ex )
       ref = ex;
     else
@@ -583,7 +583,7 @@ public:
       return TRUE;
     }
 
-    if ( (ex = PL_exception(0)) )
+    if ( (ex = Plx_exception(0)) )
       throw PlResourceError(ex);
 
     return FALSE;
@@ -881,7 +881,7 @@ __inline int PlTerm::operator =(const PlTerm &t2)	/* term = term */
 { int rc = PL_unify(ref, t2.ref);
   term_t ex;
 
-  if ( !rc && (ex=PL_exception(0)) )
+  if ( !rc && (ex=Plx_exception(0)) )
     throw PlResourceError(ex);
   return rc;
 }
@@ -890,7 +890,7 @@ __inline int PlTerm::operator =(const PlAtom &a)	/* term = atom */
 { int rc = PL_unify_atom(ref, a.handle);
   term_t ex;
 
-  if ( !rc && (ex=PL_exception(0)) )
+  if ( !rc && (ex=Plx_exception(0)) )
     throw PlResourceError(ex);
   return rc;
 }
@@ -899,7 +899,7 @@ __inline int PlTerm::operator =(const char *v)		/* term = atom */
 { int rc = PL_unify_atom_chars(ref, v);
   term_t ex;
 
-  if ( !rc && (ex=PL_exception(0)) )
+  if ( !rc && (ex=Plx_exception(0)) )
     throw PlResourceError(ex);
   return rc;
 }
@@ -908,7 +908,7 @@ __inline int PlTerm::operator =(const wchar_t *v)	/* term = atom */
 { int rc = PL_unify_wchars(ref, PL_ATOM, static_cast<size_t>(-1), v);
   term_t ex;
 
-  if ( !rc && (ex=PL_exception(0)) )
+  if ( !rc && (ex=Plx_exception(0)) )
     throw PlResourceError(ex);
   return rc;
 }
@@ -917,7 +917,7 @@ __inline int PlTerm::operator =(long v)
 { int rc = PL_unify_integer(ref, v);
   term_t ex;
 
-  if ( !rc && (ex=PL_exception(0)) )
+  if ( !rc && (ex=Plx_exception(0)) )
     throw PlResourceError(ex);
   return rc;
 }
@@ -926,7 +926,7 @@ __inline int PlTerm::operator =(int v)
 { int rc = PL_unify_integer(ref, v);
   term_t ex;
 
-  if ( !rc && (ex=PL_exception(0)) )
+  if ( !rc && (ex=Plx_exception(0)) )
     throw PlResourceError(ex);
   return rc;
 }
@@ -935,7 +935,7 @@ __inline int PlTerm::operator =(double v)
 { int rc = PL_unify_float(ref, v);
   term_t ex;
 
-  if ( !rc && (ex=PL_exception(0)) )
+  if ( !rc && (ex=Plx_exception(0)) )
     throw PlResourceError(ex);
   return rc;
 }
@@ -944,7 +944,7 @@ __inline int PlTerm::operator =(const PlFunctor &f)
 { int rc = PL_unify_functor(ref, f.functor);
   term_t ex;
 
-  if ( !rc && (ex=PL_exception(0)) )
+  if ( !rc && (ex=Plx_exception(0)) )
     throw PlResourceError(ex);
   return rc;
 }
@@ -1227,7 +1227,7 @@ PlQuery::next_solution()
     PL_close_query(qid);
     qid = 0;
 
-    if ( (ex = PL_exception(0)) )
+    if ( (ex = Plx_exception(0)) )
       PlException(ex).cppThrow();
   }
   return rval;

--- a/SWI-cpp2-plx.h
+++ b/SWI-cpp2-plx.h
@@ -124,7 +124,7 @@ PLX_ASIS(PLX_BOOL                , can_yield                       , (), ())
 PLX_WRAP(PLX_BOOL                , call                            , (term_t t, module_t m), (t, m))
 // TODO: Needs special case - see PL_next_solution():
 //       [[nodiscard]] int PL_call_predicate(module_t m, int debug, predicate_t pred, term_t t0);
-PLX_ASIS(term_t                  , exception                       , (qid_t qid), (qid))
+PLX_ASIS(term_t                  , exception                       , (qid_t qid = 0), (qid))
 PLX_ASIS(PLX_BOOL                , raise_exception                 , (term_t exception), (exception))
 // Deprecated: int PL_throw(term_t exception);
 PLX_VOID(void                    , clear_exception                 , (), ())

--- a/SWI-cpp2.cpp
+++ b/SWI-cpp2.cpp
@@ -67,7 +67,7 @@ bool ex_is_resource_error(PlTerm ex)
 _SWI_CPP2_CPP_inline
 void
 PlWrap_fail(qid_t qid)
-{ PlTerm ex(PL_exception(qid));
+{ PlTerm ex(Plx_exception(qid));
   if ( ex.not_null() )
   { // The error(resource_error(stack), _) exception is special because
     // nothing can be put on the stack, so all we can do is report failure
@@ -86,7 +86,7 @@ PlWrap_fail(qid_t qid)
 _SWI_CPP2_CPP_inline
 void
 PlEx_fail(qid_t qid)
-{ PlTerm ex(PL_exception(qid));
+{ PlTerm ex(Plx_exception(qid));
   if ( ex.not_null() )
   { // The error(resource_error(stack), _) exception is special because
     // nothing can be put on the stack, so all we can do is report failure

--- a/SWI-cpp2.cpp
+++ b/SWI-cpp2.cpp
@@ -76,7 +76,7 @@ PlWrap_fail(qid_t qid)
     // this particular exception.
     if ( ex_is_resource_error(ex) )
       throw PlExceptionFail();
-    const PlException ex2(ex);
+    const PlExceptionFromTerm ex2(ex); // PL_clear_exception() clears ex.
     Plx_clear_exception(); // See https://swi-prolog.discourse.group/t/cpp2-exceptions/6040/66
     throw ex2;
   }
@@ -95,7 +95,7 @@ PlEx_fail(qid_t qid)
     // this particular exception.
     if ( ex_is_resource_error(ex) )
       throw PlExceptionFail();
-    const PlException ex2(ex);
+    const PlExceptionFromTerm ex2(ex); // PL_clear_exception() clears ex.
     Plx_clear_exception(); // See https://swi-prolog.discourse.group/t/cpp2-exceptions/6040/66
     throw ex2;
   } else
@@ -188,7 +188,7 @@ PlContext()
 _SWI_CPP2_CPP_inline
 PlException
 PlGeneralError(PlTerm inside)
-{ return PlException(PlCompound("error", PlTermv(inside, PlTerm_var())));
+{ return PlExceptionFromTerm(PlCompound("error", PlTermv(inside, PlTerm_var())));
 }
 
 _SWI_CPP2_CPP_inline
@@ -267,11 +267,15 @@ PlResourceError(const std::string& resource)
 _SWI_CPP2_CPP_inline
 PlException
 PlUnknownError(const std::string& description)
-{ // For PlWrap()
-  return PlGeneralError(PlCompound("unknown_error",
-                                   PlTermv(PlTerm_atom(description))));
+{ return PlUnknownError(PlTerm_atom(description));
 }
 
+_SWI_CPP2_CPP_inline
+PlException
+PlUnknownError(PlTerm description)
+{  return PlGeneralError(PlCompound("unknown_error",
+                                    PlTermv(description)));
+}
 
 
 
@@ -692,7 +696,7 @@ _SWI_CPP2_CPP_inline
 PlCompound::PlCompound(const wchar_t *text)
 { term_t t = Plx_new_term_ref();
   if ( !Plx_wchars_to_term(text, t) )
-    throw PlException(PlTerm(t));
+    throw PlGeneralError(PlTerm(t));
   Plx_put_term(unwrap(), t);
 }
 
@@ -713,7 +717,7 @@ PlCompound::PlCompound(const std::wstring& text)
 
   // TODO: what is wchar_t equivalent of PL_put_term_from_chars()?
   if ( !Plx_wchars_to_term(text.c_str(), t) ) // TODO: use text.size()
-    throw PlException(PlTerm(t));
+    throw PlGeneralError(PlTerm(t));
   Plx_put_term(unwrap(), t);
 }
 

--- a/SWI-cpp2.h
+++ b/SWI-cpp2.h
@@ -1217,13 +1217,11 @@ private:
 
 class PlException : public PlExceptionBase
 {
-public:
+protected:
   explicit PlException(PlTerm t)
     : term_rec_(t) { }
 
-  explicit PlException(PlAtom a)
-    : term_rec_(PlTerm_atom(a)) { }
-
+public:
   PlException(const PlException& e)
     : term_rec_(e.term_rec_.duplicate()),
       what_str_(e.what_str_)
@@ -1283,6 +1281,19 @@ protected:
   // PlTerm string_term() const; // TODO: revive this
 };
 
+class PlExceptionFromTerm : public PlException
+{
+public:
+  explicit PlExceptionFromTerm(PlTerm t)
+    : PlException(t) { }
+};
+
+class PlExceptionFromQid : public PlException
+{
+public:
+  explicit PlExceptionFromQid(qid_t qid = 0)
+    : PlException(Plx_exception(qid)) { }
+};
 
 PlException PlGeneralError(PlTerm inside);
 
@@ -1305,6 +1316,8 @@ PlException PlPermissionError(const std::string& op, const std::string& type, Pl
 PlException PlResourceError(const std::string& resource);
 
 PlException PlUnknownError(const std::string& description);
+
+PlException PlUnknownError(PlTerm description);
 
 void PlWrap_fail(qid_t qid = 0);
 

--- a/SWI-cpp2.h
+++ b/SWI-cpp2.h
@@ -1306,7 +1306,7 @@ PlException PlResourceError(const std::string& resource);
 
 PlException PlUnknownError(const std::string& description);
 
-void PlWrap_fail(qid_t qid);
+void PlWrap_fail(qid_t qid = 0);
 
 template<typename C_t> C_t
 PlWrap(C_t rc, qid_t qid)
@@ -1492,7 +1492,7 @@ public:
                                      av.termv())),
       flags_(flags)
   { }
-  PlQuery(qid_t qid)
+  PlQuery(qid_t qid = 0)
     : WrappedC<qid_t>(qid)
   { }
 

--- a/pl2cpp.doc
+++ b/pl2cpp.doc
@@ -649,6 +649,10 @@ enclosing code doesn't intercept the exception, the \ctype{PlException}
 object is turned back into a Prolog error when control returns to Prolog
 from the PREDICATE() macros. This is a subclass of \ctype{PlExceptionBase},
 which is a subclass of \ctype{std::exception}.
+Note that the constructor is protected; in general, you should use
+PlTypeError(), PlDomainError(), etc. instead; or, if you wish to propagate
+and error, use
+\ctype{PlExceptionFromTerm} or \ctype{PlExceptionFromQid}.
     \classitem{PlFrame}
 This utility-class can be used to discard unused term-references as well
 as to do \jargon{data-backtracking}. It calls PL_open_foreign_frame()
@@ -1580,7 +1584,7 @@ Ths could fixed by adding \exam{delete data} before
 throwing the \const{runtime_error}; but this doesn't handle the
 situation of \exam{data->validate()} throwing an exception (which
 would require a catch/throw).
-Instead, it's easiser to use \ctype{std::unique_ptr}, which takes
+Instead, it's easier to use \ctype{std::unique_ptr}, which takes
 care of every return or exception path:
 \begin{code}
 MyData *foo(int some_value) {
@@ -4023,7 +4027,7 @@ _pl_hello__1(term_t t0, int arity, control_t ctx)
 { (void)arity; (void)ctx;
   try
   { return pl_hello__1(PlTermv(1, t0));
-  } catch( PlFail& )
+  } catch ( PlFail& )
   { return false;
   } catch ( PlException& ex )
   { return ex.plThrow();
@@ -4208,7 +4212,7 @@ appropriate error name. For example, the following code catches
 \begin{code}
 try
 { do_something(...);
-} catch (const PlException& e)
+} catch ( const PlException& e)
 { PlTerm e_t = e.term();
   PlAtom ATOM_type_error("type_error");
   // e_t.name() == PlAtom("error") && e_t.arity() == 2
@@ -4221,9 +4225,15 @@ try
 The convenience functions are PlTypeEror() and PlDomainError(),
 PlDomainError(), PlInstantiationError(), PlExistenceError(),
 PlUninstantiationError(), PlRepresentationError(),
-PlPermissionError(), PlResourceError(), PlUnknownError(). There is
-also a PlGeneralError(inside) that creates \exam{error(inside,_)}
-terms and is used by the other error convience functions.
+PlPermissionError(), PlResourceError(), PlUnknownError().
+
+There is also a PlGeneralError(inside_term) that creates
+\exam{error(Inside_term,_)} terms and is used by the other error
+convience functions.
+
+The easiest way to access the exception from PlCall() is
+by using \ctype{PlExceptionFromQid} - you can then check for
+an exception by using the PlException::is_null() method.
 
 To throw an exception, create an instance of \ctype{PlException} and
 use \exam{throw}. This is intercepted by the PREDICATE macro and
@@ -4232,7 +4242,21 @@ turned into a Prolog exception. See \secref{cpp2-exceptions-notes}.
 \begin{code}
   char *data = "users";
 
-  throw PlException(PlCompound("no_database", PlTerm(data)));
+  throw PlGeneralError(PlCompound("no_database", PlTerm(data)));
+\end{code}
+
+Sometimes, you may need to more control over the exception term or you
+may need to copy a term (e.g., PL_clear_exception() clears the error
+term, so it may need to be copied for a rethrow); for this, use
+PlExceptionFromTerm(). Note that unlike the other ways of creating
+exceptions, this does not create a term of the form
+\exam{error(Term,_)}; if you wish to create your own form of an error,
+you should use PlGeneralError(). But if you need to create a term that
+isn't the functor \exam{error}, you can do something like this:
+\begin{code}
+  throw PlExceptionFromTerm(
+           PlCompound("my_weird_error_term",
+                      PlTermv(t, PlTerm_var())));
 \end{code}
 
 \subsection{The class PlException}
@@ -4255,10 +4279,19 @@ or within the context of a \ctype{PlEngine} (and \ctype{PlFrame};
 see \secref{cpp2-embedding}).
 The term is copied so that it is available outside of the
 context of the frame that created it.
+
+You cannot create a \ctype{PlExceptionBase} or \ctype{PlException}
+because their constructors are protected.
+
+In this diagram, names with \exam{()} are functions; the others
+are classes.
+
 \begin{verbatim}
 std::exception
 *-- PlExceptionBase
     *-- PlException
+    |   *.. PlExceptionFromTerm
+    |   *.. PlExceptionFromQid
     |   *.. PlDomainError()
     |   *.. PlExistenceError()
     |   *.. PlGeneralError()
@@ -4298,6 +4331,8 @@ Currently defined methods are:
     \constructor{PlException}{const PlTerm \&t}
 Create an exception from a general Prolog term.  This provides the
 interface for throwing any Prolog terms as an exception.
+This constructor is protected; instead you should use
+\ctype{PlExceptionFromTerm} or \ctype{PlExceptionFromQid}.
     \cfunction{char*}{what}{}
     See ctype{std::exception::what()}. Note that if this is called
     outside the Prolog frame where the exception was created, there
@@ -4429,7 +4464,7 @@ variable, and behaviour of raising an exception that is an unbound
 term is undefined, including the possibility of causing a crash or
 corrupting data.
 
-The Prolog exception term error(Formal, _) is special.  If the 2nd
+The Prolog exception term \exam{error(Formal, _)} is special.  If the 2nd
 argument of error/2 is undefined, and the term is thrown, the system
 finds the catcher (if any), and calls the hooks in
 library(prolog_stack) to add the context and stack trace information

--- a/test_cpp.cpp
+++ b/test_cpp.cpp
@@ -369,7 +369,7 @@ PREDICATE(if_then_ffi, 4)
   term_t t1 = A1.unwrap(), t2 = A2.unwrap();
   int t1_t2_unified = PL_unify(t1, t2);
   if ( !t1_t2_unified )
-  { if ( Plx_exception(0) )
+  { if ( Plx_exception() )
       { PL_close_foreign_frame(fid);
         return FALSE;
       }
@@ -477,7 +477,7 @@ PREDICATE(cpp_call_, 3)
     { if ( verbose )
 	strm.printf("cpp_call result: rc=%d: %s\n", rc, A1.as_string().c_str());
     } else
-    { PlTerm ex(Plx_exception(0));
+    { PlTerm ex(Plx_exception());
       if ( ex.is_null() )
       { if ( verbose )
 	  strm.printf("cpp_call failed\n");
@@ -502,7 +502,7 @@ PREDICATE(cpp_call_, 3)
 PREDICATE(cpp_atom_codes, 2)
 { int rc = PlCall("atom_codes", PlTermv(A1, A2));
   if ( !rc )
-  { PlException ex(PlTerm(Plx_exception(0)));
+  { PlException ex(PlTerm(Plx_exception()));
     PlStream strm(Scurrent_output);
     if ( ex.is_null() )
       strm.printf("atom_codes failed\n");

--- a/test_cpp.cpp
+++ b/test_cpp.cpp
@@ -369,7 +369,7 @@ PREDICATE(if_then_ffi, 4)
   term_t t1 = A1.unwrap(), t2 = A2.unwrap();
   int t1_t2_unified = PL_unify(t1, t2);
   if ( !t1_t2_unified )
-  { if ( Plx_exception() )
+  { if ( Plx_exception(0) )
       { PL_close_foreign_frame(fid);
         return FALSE;
       }
@@ -477,7 +477,7 @@ PREDICATE(cpp_call_, 3)
     { if ( verbose )
 	strm.printf("cpp_call result: rc=%d: %s\n", rc, A1.as_string().c_str());
     } else
-    { PlTerm ex(Plx_exception());
+    { PlTerm ex(Plx_exception(0));
       if ( ex.is_null() )
       { if ( verbose )
 	  strm.printf("cpp_call failed\n");
@@ -502,7 +502,7 @@ PREDICATE(cpp_call_, 3)
 PREDICATE(cpp_atom_codes, 2)
 { int rc = PlCall("atom_codes", PlTermv(A1, A2));
   if ( !rc )
-  { PlException ex(PlTerm(Plx_exception()));
+  { PlException ex{PlTerm(Plx_exception())};
     PlStream strm(Scurrent_output);
     if ( ex.is_null() )
       strm.printf("atom_codes failed\n");

--- a/test_cpp.cpp
+++ b/test_cpp.cpp
@@ -369,7 +369,7 @@ PREDICATE(if_then_ffi, 4)
   term_t t1 = A1.unwrap(), t2 = A2.unwrap();
   int t1_t2_unified = PL_unify(t1, t2);
   if ( !t1_t2_unified )
-  { if ( PL_exception(0) )
+  { if ( Plx_exception(0) )
       { PL_close_foreign_frame(fid);
         return FALSE;
       }

--- a/test_cpp.cpp
+++ b/test_cpp.cpp
@@ -114,6 +114,14 @@ PREDICATE(hello, 2)
   return A2.unify_string(buffer.str());
 }
 
+PREDICATE(helloex, 0)
+{ throw PlUnknownError("an exception");
+}
+
+PREDICATE(helloex, 1)
+{ throw PlUnknownError(A1);
+}
+
 PREDICATE(hello2, 2)
 { PlAtom atom_a1(A1.as_atom());
   std::stringstream buffer;
@@ -501,13 +509,16 @@ PREDICATE(cpp_call_, 3)
 
 PREDICATE(cpp_atom_codes, 2)
 { int rc = PlCall("atom_codes", PlTermv(A1, A2));
+  PlStream strm(Scurrent_output); // for debugging output
   if ( !rc )
-  { PlException ex{PlTerm(Plx_exception())};
-    PlStream strm(Scurrent_output);
+  { PlExceptionFromQid ex;
     if ( ex.is_null() )
       strm.printf("atom_codes failed\n");
     else
       strm.printf("atom_codes failed: ex: %s\n", ex.as_string().c_str()); // Shouldn't happen
+    throw ex;
+  } else
+  { strm.printf("atom_codes succeeded: %s -> %s\n", A1.as_string().c_str(), A2.as_string().c_str());
   }
   return rc;
 }

--- a/test_cpp.pl
+++ b/test_cpp.pl
@@ -92,6 +92,11 @@ test(hello, Out == "hello hello hello") :-
     % hello :- write('hello hello hello')
     with_output_to(string(Out), hello).
 
+test(helloex, error(unknown_error('an exception'))) :-
+    helloex.
+test(helloex, error(unknown_error(foo(bar)))) :-
+    helloex(foo(bar)).
+
 test(hello, Out == "Hello WORLD\nHello WORLD\nHello WORLD\nHello WORLD\nHello WORLD\n") :-
     hello("WORLD", Out).
 test(hello, error(representation_error(encoding))) :-
@@ -283,6 +288,7 @@ test(cappend, fail) :-
 test(cappend, fail) :-
     cappend([a,b,c], [d,e], [a,b,c,d,e|f]).
 
+%% TODO: add more tests of cpp_call/2
 test(cpp_call, Out == "abc\n") :-
     with_output_to(string(Out),
 		   cpp_call(writeln(abc), [normal])).
@@ -290,6 +296,13 @@ test(cpp_call, Out == "abc\n") :-
 cpp_call(Goal, Flags) :-
     query_flags(Flags, CombinedFlag),
     cpp_call_(Goal, CombinedFlag, false).
+
+test(cpp_atom_codes, Out == [102,111,111]) :-
+    cpp_atom_codes(foo, Out).
+test(cpp_atom_codes, Out == [49,50,51]) :-
+    cpp_atom_codes(123, Out).
+test(cpp_atom_codes, error(type_error(atom,a(f)))) :-
+    cpp_atom_codes(a(f), _Out).
 
 test(square_roots_2, Result == [0.0, 1.0, 1.4142135623730951, 1.7320508075688772, 2.0]) :-
     square_roots(4, Result).


### PR DESCRIPTION
A few of the C++-generated exceptions weren't of the form `error(Term,_)`; also there was no warning if `PlException` was used instead of `PlGeneralError`.

There are also a couple of clean-up commits.