### PR TITLE
Fix MSVC C4996 warning: strdup POSIX name deprecated

### DIFF
--- a/test_cpp.cpp
+++ b/test_cpp.cpp
@@ -56,6 +56,7 @@ how the various predicates can be called from Prolog.
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 #define _CRT_SECURE_NO_WARNINGS 1
+#define _CRT_NONSTDC_NO_DEPRECATE 1
 #define PROLOG_MODULE "user"
 #include <iostream>
 #include <sstream>


### PR DESCRIPTION
## Summary

Fix MSVC C4996 warning for `strdup` POSIX name deprecation in `test_cpp.cpp`.

### Changes

- Add `_CRT_NONSTDC_NO_DEPRECATE` alongside existing `_CRT_SECURE_NO_WARNINGS` to suppress the POSIX name deprecation warning for `strdup`

### Note

The file already had `_CRT_SECURE_NO_WARNINGS` for `strcpy`/`strcat` warnings, but `strdup` triggers a separate POSIX name deprecation controlled by `_CRT_NONSTDC_NO_DEPRECATE`.

### Testing

Built and tested with MSVC (Visual Studio 2026) on Windows x64. Warning is resolved.