### PR TITLE
UBSAN: use size_t instead of int for arity

### DIFF
--- a/SWI-cpp2.h
+++ b/SWI-cpp2.h
@@ -1861,7 +1861,7 @@ private:
 	static foreign_t \
 	pl_ ## name ## __ ## arity(PlTermv PL_av); \
 	static foreign_t \
-	_pl_ ## name ## __ ## arity(term_t t0, int a, control_t c) \
+	_pl_ ## name ## __ ## arity(term_t t0, size_t a, control_t c) \
 	{ (void)a; (void)c; \
           foreign_t rc; \
 	  try \
@@ -1879,7 +1879,7 @@ private:
 	static foreign_t \
 	pl_ ## name ## __0(void); \
 	static foreign_t \
-	_pl_ ## name ## __0(term_t t0, int a, control_t c) \
+	_pl_ ## name ## __0(term_t t0, size_t a, control_t c) \
 	{ (void)t0; (void)a; (void)c; \
           foreign_t rc; \
 	  try \
@@ -1897,7 +1897,7 @@ private:
 	static foreign_t \
 	pl_ ## name ## __ ## arity(PlTermv PL_av, PlControl handle); \
 	static foreign_t \
-	_pl_ ## name ## __ ## arity(term_t t0, int a, control_t c) \
+	_pl_ ## name ## __ ## arity(term_t t0, size_t a, control_t c) \
 	{ (void)a; \
           foreign_t rc; \
 	  try \


### PR DESCRIPTION
That is the error 

```
tmp/RtmpODtnkH/R.INSTALLaa04815dd6d/rswipl/src/swipl-devel/src/pl-vmi.c:4343:3: runtime error: call to function _pl_r_eval__2(unsigned long, int, __PL_foreign_context*) through pointer to incorrect function type 'unsigned long (*)(unsigned long, unsigned long, struct foreign_context *)'
/tmp/Rtmpm8peJI/Rbuild4c1e383dae0a/rolog/src/rolog.cpp:1320: note: _pl_r_eval__2(unsigned long, int, __PL_foreign_context*) defined here
```